### PR TITLE
feat: standardize snippet metadata, add common snippets, and add docs/linting tooling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run HTMLHint
+        run: npx --yes htmlhint "devsnips/snippets/**/*.html"
+
+      - name: Run ESLint
+        run: npx --yes eslint "devsnips/snippets/js-snippets/**/*.js"

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,11 @@
+{
+  "tagname-lowercase": true,
+  "attr-lowercase": true,
+  "attr-value-double-quotes": true,
+  "doctype-first": false,
+  "tag-pair": true,
+  "spec-char-escape": true,
+  "id-unique": true,
+  "src-not-empty": true,
+  "title-require": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## 2026-03-10
+
+### Added
+- Added new HTML snippets: modal dialog, accordion FAQ layout, pricing card, skeleton loader, and toast notification markup.
+- Added new CSS snippets: dark mode variables, responsive grid system, animated hamburger menu, and focus-visible accessibility styles.
+- Added new JS snippets: debounce utility, clipboard copy helper, local storage wrapper, form validator, and lazy image loader.
+- Added `snippets-index.json` containing metadata for all snippet files.
+- Added shared project config: `.editorconfig`, `.htmlhintrc`, `eslint.config.js`, and GitHub Actions lint workflow at `.github/workflows/lint.yml`.
+
+### Changed
+- Added standardized snippet header comments to existing snippet files in `devsnips/snippets/html-snippets`, `devsnips/snippets/css-snippets`, and `devsnips/snippets/js-snippets` where missing.
+- Rewrote `README.md` with a clearer structure, usage guide, badges, and a full snippet table.
+- Updated `CONTRIBUTING.md` with explicit code style rules, header templates, and a contribution checklist.
+- Updated `PULL_REQUEST_TEMPLATE.md` with accessibility and cross-browser testing checks.
+
+### Tradeoffs / Decisions for Maintainer Review
+- Snippet descriptions in `snippets-index.json` are generated from filenames for consistency and maintainability; maintainers may want to manually curate descriptions over time.
+- Workflow linting currently targets snippet directories only to avoid failures from demo/landing-page files with different structure.
+- Existing snippet formatting was standardized by documentation and headers first; full per-file semantic and indentation normalization across all legacy snippets was not performed in this pass to keep changes reviewable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,79 +1,70 @@
 # 🤝 Contributing to DevSnips
 
-Thank you for considering a contribution to **DevSnips** — a curated collection of reusable frontend code snippets in HTML, CSS, and JavaScript.
+Thanks for helping improve **DevSnips**! This repository is a lightweight collection of framework-free frontend snippets.
 
-We welcome clean, functional, and well-documented snippets that can help developers build faster and smarter.
+## Contribution flow
 
----
+1. Fork the repository.
+2. Create a descriptive branch, for example `feat/modal-snippet`.
+3. Add or update snippets in:
+   - `devsnips/snippets/html-snippets/`
+   - `devsnips/snippets/css-snippets/`
+   - `devsnips/snippets/js-snippets/`
+4. Update `snippets-index.json` when you add/remove snippets.
+5. Run local checks and open a PR.
 
-## 📦 What You Can Contribute
+## Code style rules
 
-You can contribute by:
+- Use **2-space indentation** for HTML, CSS, and JS.
+- Keep snippets focused on one idea/component.
+- Use semantic HTML (`main`, `section`, `button`, etc.) where applicable.
+- Include accessibility support (labels, ARIA attributes, keyboard-friendly behavior).
+- Prefer modern JavaScript (`const`/`let`, arrow functions, array methods).
+- Avoid external dependencies unless absolutely necessary.
 
-- Adding a new HTML, CSS, or JavaScript snippet
-- Improving or refactoring an existing snippet
-- Fixing typos or improving documentation (README or snippet comments)
-- Organizing snippets with better naming or folder structure
-- Suggesting ideas via GitHub Issues
+## Standard snippet comment header
 
----
+Use this header at the top of every snippet file.
 
-## 📁 File Structure Overview
-devsnips/
-├── html/ → UI layouts, components, forms
-├── css/ → Effects, animations, UI styling
-├── js/ → Functional utilities, interactivity
+### HTML
 
+```html
+<!--
+Snippet Name: <name>
+Description: <one-line purpose>
+Author: <github handle or DevSnips Contributors>
+Usage Example: <short usage instruction>
+-->
+```
 
----
+### CSS
 
-## 🛠 How to Contribute
+```css
+/*
+Snippet Name: <name>
+Description: <one-line purpose>
+Author: <github handle or DevSnips Contributors>
+Usage Example: <short usage instruction>
+*/
+```
 
-1. **Fork the repository**  
-2. **Create a new branch**  
-   Use a descriptive name like `feature/navbar-snippet` or `fix/readme-typo`
+### JavaScript
 
-3. **Add or edit your snippet**
-   - Place it in the correct folder: `html/`, `css/`, or `js/`
-   - Use **descriptive file names** like `animated-button.css`, not `button1.css`
-   - Add a **comment header** in your file like this:
-     ```html
-     <!--
-     Snippet: Responsive Navbar
-     Description: A fully responsive navbar with hamburger menu for mobile view.
-     Author: @your-github-username
-     -->
-     ```
+```js
+/**
+ * Snippet Name: <name>
+ * Description: <one-line purpose>
+ * Author: <github handle or DevSnips Contributors>
+ * Usage Example: <short usage instruction>
+ */
+```
 
-4. **Test your snippet**
-   Ensure it works well in a basic HTML test file or browser.
+## Contributor checklist
 
-5. **Commit with a clear message**
-   Example: `feat: add responsive navbar snippet`
-
-6. **Push and open a Pull Request**
-   - Explain what you added and why
-   - If it's based on an open issue, mention it with `Closes #issue-number`
-
----
-
-## 📌 Code Style Guidelines
-
-- Keep code readable and consistently indented (2 or 4 spaces)
-- Avoid unnecessary libraries or frameworks
-- Keep JS snippets modular and functional (no global variables)
-- Use only **vanilla HTML/CSS/JS** — no dependencies
-- Keep snippets focused and minimal
-
----
-
-## 🛡 License
-
-By contributing, you agree that your submissions will be licensed under the [MIT License](LICENSE) of this repository.
-
----
-
-## 🙌 Thank You
-
-Your contributions make DevSnips better for everyone.  
-Feel free to open an issue if you need help or have questions before contributing.
+- [ ] Snippet includes the standard comment header.
+- [ ] Snippet follows 2-space indentation.
+- [ ] HTML snippets include `<!DOCTYPE html>`, `lang`, `charset`, and viewport meta.
+- [ ] Accessibility has been reviewed (semantic tags + ARIA where needed).
+- [ ] JavaScript uses `const`/`let` and modern syntax.
+- [ ] Snippet added to `snippets-index.json`.
+- [ ] Tested in at least two modern browsers.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,25 @@
-## 🚀 Pull Request Overview
+## 🚀 Pull Request Summary
 
-### What does this PR do?
-<!-- Brief description of the feature or fix -->
+### What does this PR change?
+<!-- Describe the snippet(s) or documentation updates in 2-4 bullets. -->
 
-### Related Issue
-Closes #[issue-number] (if applicable)
+### Related issue
+Closes #<issue-number> (if applicable)
 
-### Changes Made
-- [ ] Added new snippet: [name]
-- [ ] Refactored existing code
-- [ ] Updated documentation
+## ✅ PR Checklist
 
-### Screenshots/Preview
-<!-- Optional: Add image or link to demo -->
+- [ ] My snippet(s) include the standard comment header.
+- [ ] I followed project formatting and code style rules.
+- [ ] I reviewed snippet accessibility (semantic HTML + ARIA where needed).
+- [ ] I tested in multiple browsers.
+- [ ] I updated `snippets-index.json` for added/removed snippets.
+- [ ] I added/updated documentation where necessary.
 
-### Checklist
-- [ ] My code follows the code style
-- [ ] I have tested this snippet
-- [ ] I have added a meaningful comment header
+## 🧪 Validation
+
+- [ ] I ran lint checks locally (HTMLHint / ESLint).
+- [ ] I tested snippet behavior manually.
+
+## 📸 Screenshots / Preview
+
+<!-- Optional for visual changes: include screenshots or a demo link. -->

--- a/README.md
+++ b/README.md
@@ -1,71 +1,416 @@
 # 🚀 DevSnips – Frontend Snippet Library
-![image](https://github.com/user-attachments/assets/dcda6dd3-85cb-4685-abc2-cf0bf1f5c7bd)
 
-[![DevSnips – Frontend Snippet Library](https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1013339&theme=dark)](https://www.producthunt.com/products/devsnips-frontend-snippet-library?utm_source=badge-featured&utm_medium=badge&utm_source=badge-devsnips-frontend-snippet-library)
-[![Featured on DevHub](https://devhub.best/images/badges/featured-on-light.svg)](https://devhub.best)
-[![Featured on Twelve Tools](https://twelve.tools/badge3-dark.svg)](https://twelve.tools)
-[![Featured on Startup Fame](https://startupfa.me/badges/featured/dark-small.webp)](https://startupfa.me/s/github-1?utm_source=github.com)
+[![Live Demo](https://img.shields.io/badge/Live%20Demo-devsnips.biz-2563eb?style=for-the-badge)](https://devsnips.biz)
+[![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=for-the-badge)](CONTRIBUTING.md)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blueviolet?style=for-the-badge)](PULL_REQUEST_TEMPLATE.md)
 
-read wiki here :- ([wiki](https://github.com/developer8sarthak/DevSnips/wiki)) 
-official site :-  ([devsnips.biz](https://devsnips.biz/))
+A curated collection of reusable **HTML**, **CSS**, and **JavaScript** snippets for shipping frontend interfaces quickly with a lightweight, no-framework approach.
 
-A curated collection of reusable **HTML**, **CSS**, and **JavaScript** code snippets to help you build faster, cleaner, and more efficient frontend interfaces.
+## How to use
 
-Ideal for students, solo developers, and creators who want copy-paste-ready code without reinventing the wheel.
+1. Browse snippets in `devsnips/snippets/{html-snippets,css-snippets,js-snippets}`.
+2. Copy the file content into your project.
+3. Customize naming, styles, and behavior for your use case.
+4. Keep snippet headers when sharing back to DevSnips.
 
----
-## 📁 Folder Structure
+## Repository structure
+
+```
 devsnips/
-├── html/ # Reusable HTML UI structures
-├── css/ # Styled components and effects
-├── js/ # JavaScript utilities and interactions
-├── README.md # Project documentation
-└── LICENSE # MIT License
+├── snippets/
+│   ├── html-snippets/
+│   ├── css-snippets/
+│   └── js-snippets/
+├── full-landing-pages/
+└── assets/
+```
 
----
+## Complete snippet index
 
-## 💡 Features
-
-- ✅ Clean, reusable code snippets
-- 🎯 Organized by language (HTML, CSS, JS)
-- 📦 Lightweight, no dependencies
-- 📚 Great for learning, prototyping, and sharing
-- 🤝 Open for contributions
-
----
-
-## 📂 Snippet Examples
-
-### HTML
-- Responsive navbar
-- Login form layout
-- Card layout for blog/articles
-
-### CSS
-- Glassmorphism card
-- Gradient button hover effects
-- Pure CSS loaders and spinners
-
-### JavaScript
-- Typewriter text effect
-- Scroll-to-top button
-- Dark mode toggle
-
----
-
-## 🚀 Getting Started
-
-Clone the repo:
-```bash
-git clone https://github.com/your-username/devsnips.git
-read wiki here :- ([wiki](https://github.com/developer8sarthak/DevSnips/wiki)) 
-🤝 Contribution Guidelines
-We welcome community contributions! To contribute:
-Fork this repository
-Create a new branch (feature/your-snippet-name)
-Add your snippet in the correct folder (html/, css/, or js/)
-Follow consistent naming and indentation
-Add a code comment header with snippet name and description
-Commit and push your changes
-Open a Pull Request with a clear title and explanation
-See CONTRIBUTING.md for detailed contribution rules (optional file to add).
+| Snippet | Category | Path | Description |
+|---|---|---|---|
+| Accordion | CSS | `devsnips/snippets/css-snippets/accordion.html` | Reusable accordion snippet. |
+| Animated Gradient Border Button | CSS | `devsnips/snippets/css-snippets/animated-gradient-border-button.html` | Reusable animated gradient border button snippet. |
+| Animated Gradient Text | CSS | `devsnips/snippets/css-snippets/animated-gradient-text.css` | Reusable animated gradient text snippet. |
+| Animated Hamburger Menu | CSS | `devsnips/snippets/css-snippets/animated-hamburger-menu.css` | Reusable animated hamburger menu snippet. |
+| Animated Hamburger Menu | CSS | `devsnips/snippets/css-snippets/animated-hamburger-menu.html` | Reusable animated hamburger menu snippet. |
+| Aspect Ratio Boxes | CSS | `devsnips/snippets/css-snippets/aspect-ratio-boxes.html` | Reusable aspect ratio boxes snippet. |
+| Auto Resizing Textarea | CSS | `devsnips/snippets/css-snippets/auto-resizing-textarea.css` | Reusable auto resizing textarea snippet. |
+| Bouncing Dots | CSS | `devsnips/snippets/css-snippets/bouncing-dots.html` | Reusable bouncing dots snippet. |
+| Box Shadow Dual | CSS | `devsnips/snippets/css-snippets/box-shadow-dual.css` | Reusable box shadow dual snippet. |
+| Button Hover Glow | CSS | `devsnips/snippets/css-snippets/button-hover-glow.css` | Reusable button hover glow snippet. |
+| Center Absolute | CSS | `devsnips/snippets/css-snippets/center-absolute.css` | Reusable center absolute snippet. |
+| Center Anything Flexbox | CSS | `devsnips/snippets/css-snippets/center-anything-flexbox.html` | Reusable center anything flexbox snippet. |
+| Center Anything Grid | CSS | `devsnips/snippets/css-snippets/center-anything-grid.html` | Reusable center anything grid snippet. |
+| Centered Loader | CSS | `devsnips/snippets/css-snippets/centered-loader.html` | Reusable centered loader snippet. |
+| Checkered Background | CSS | `devsnips/snippets/css-snippets/checkered-background.css` | Reusable checkered background snippet. |
+| Clearfix Hack | CSS | `devsnips/snippets/css-snippets/clearfix-hack.css` | Reusable clearfix hack snippet. |
+| Conditional Theming Container Query | CSS | `devsnips/snippets/css-snippets/conditional-theming-container-query.css` | Reusable conditional theming container query snippet. |
+| Conic Gradient Pie Chart | CSS | `devsnips/snippets/css-snippets/conic-gradient-pie-chart.css` | Reusable conic gradient pie chart snippet. |
+| Consistent Link Underline | CSS | `devsnips/snippets/css-snippets/consistent-link-underline.css` | Reusable consistent link underline snippet. |
+| Container Query Card | CSS | `devsnips/snippets/css-snippets/container-query-card.css` | Reusable container query card snippet. |
+| Css Masonry Layout | CSS | `devsnips/snippets/css-snippets/css-masonry-layout.html` | Reusable css masonry layout snippet. |
+| Css Only Accordion | CSS | `devsnips/snippets/css-snippets/css-only-accordion.html` | Reusable css only accordion snippet. |
+| Css Only Notification Badge | CSS | `devsnips/snippets/css-snippets/css-only-notification-badge.html` | Reusable css only notification badge snippet. |
+| Css Only Progress Bar | CSS | `devsnips/snippets/css-snippets/css-only-progress-bar.html` | Reusable css only progress bar snippet. |
+| Css Only Star Rating | CSS | `devsnips/snippets/css-snippets/css-only-star-rating.html` | Reusable css only star rating snippet. |
+| Css Only Toggle Switch | CSS | `devsnips/snippets/css-snippets/css-only-toggle-switch.css` | Reusable css only toggle switch snippet. |
+| Css Only Tooltip | CSS | `devsnips/snippets/css-snippets/css-only-tooltip.html` | Reusable css only tooltip snippet. |
+| Css Triangle Shape | CSS | `devsnips/snippets/css-snippets/css-triangle-shape.css` | Reusable css triangle shape snippet. |
+| Css Variable Fallback | CSS | `devsnips/snippets/css-snippets/css-variable-fallback.css` | Reusable css variable fallback snippet. |
+| Custom Focus Ring | CSS | `devsnips/snippets/css-snippets/custom-focus-ring.css` | Reusable custom focus ring snippet. |
+| Custom Scrollbar Webkit | CSS | `devsnips/snippets/css-snippets/custom-scrollbar-webkit.css` | Reusable custom scrollbar webkit snippet. |
+| Dark Light Mode Theming | CSS | `devsnips/snippets/css-snippets/dark-light-mode-theming.css` | Reusable dark light mode theming snippet. |
+| Dark Mode Css Variables | CSS | `devsnips/snippets/css-snippets/dark-mode-css-variables.css` | Reusable dark mode css variables snippet. |
+| Direction Aware Hover | CSS | `devsnips/snippets/css-snippets/direction-aware-hover.css` | Reusable direction aware hover snippet. |
+| Disabled Element Style | CSS | `devsnips/snippets/css-snippets/disabled-element-style.css` | Reusable disabled element style snippet. |
+| Dotted Separator | CSS | `devsnips/snippets/css-snippets/dotted-separator.css` | Reusable dotted separator snippet. |
+| Element Mask Clip Path | CSS | `devsnips/snippets/css-snippets/element-mask-clip-path.css` | Reusable element mask clip path snippet. |
+| Equal Height Cards Flexbox | CSS | `devsnips/snippets/css-snippets/equal-height-cards-flexbox.html` | Reusable equal height cards flexbox snippet. |
+| Equal Height Cards Grid | CSS | `devsnips/snippets/css-snippets/equal-height-cards-grid.html` | Reusable equal height cards grid snippet. |
+| Fade In On Scroll | CSS | `devsnips/snippets/css-snippets/fade-in-on-scroll.css` | Reusable fade in on scroll snippet. |
+| Flip Card | CSS | `devsnips/snippets/css-snippets/flip-card.html` | Reusable flip card snippet. |
+| Floating Label | CSS | `devsnips/snippets/css-snippets/floating-label.html` | Reusable floating label snippet. |
+| Focus Visible Accessibility | CSS | `devsnips/snippets/css-snippets/focus-visible-accessibility.css` | Reusable focus visible accessibility snippet. |
+| Frosted Glass Card | CSS | `devsnips/snippets/css-snippets/frosted-glass-card.html` | Reusable frosted glass card snippet. |
+| Frosted Glass Effect | CSS | `devsnips/snippets/css-snippets/frosted-glass-effect.css` | Reusable frosted glass effect snippet. |
+| Full Screen Overlay | CSS | `devsnips/snippets/css-snippets/full-screen-overlay.css` | Reusable full screen overlay snippet. |
+| Future Css Color Contrast | CSS | `devsnips/snippets/css-snippets/future-css-color-contrast.css` | Reusable future css color contrast snippet. |
+| Future Css Conditional If | CSS | `devsnips/snippets/css-snippets/future-css-conditional-if.css` | Reusable future css conditional if snippet. |
+| Glassmorphism Card | CSS | `devsnips/snippets/css-snippets/glassmorphism-card.html` | Reusable glassmorphism card snippet. |
+| Global Box Sizing Reset | CSS | `devsnips/snippets/css-snippets/global-box-sizing-reset.css` | Reusable global box sizing reset snippet. |
+| Gradient Button | CSS | `devsnips/snippets/css-snippets/gradient-button.html` | Reusable gradient button snippet. |
+| Has Selector Parent Styling | CSS | `devsnips/snippets/css-snippets/has-selector-parent-styling.css` | Reusable has selector parent styling snippet. |
+| Hide Scrollbar Scrollable | CSS | `devsnips/snippets/css-snippets/hide-scrollbar-scrollable.css` | Reusable hide scrollbar scrollable snippet. |
+| Holy Grail Layout | CSS | `devsnips/snippets/css-snippets/holy-grail-layout.html` | Reusable holy grail layout snippet. |
+| Hover Reveal Overlay | CSS | `devsnips/snippets/css-snippets/hover-reveal-overlay.css` | Reusable hover reveal overlay snippet. |
+| Mix Blend Mode Multiply | CSS | `devsnips/snippets/css-snippets/mix-blend-mode-multiply.css` | Reusable mix blend mode multiply snippet. |
+| Modal Dialog Backdrop | CSS | `devsnips/snippets/css-snippets/modal-dialog-backdrop.css` | Reusable modal dialog backdrop snippet. |
+| Multi Line Clamp | CSS | `devsnips/snippets/css-snippets/multi-line-clamp.css` | Reusable multi line clamp snippet. |
+| Native Css Nesting | CSS | `devsnips/snippets/css-snippets/native-css-nesting.css` | Reusable native css nesting snippet. |
+| Neon Text | CSS | `devsnips/snippets/css-snippets/neon-text.html` | Reusable neon text snippet. |
+| Neumorphic Button Effect | CSS | `devsnips/snippets/css-snippets/neumorphic-button-effect.css` | Reusable neumorphic button effect snippet. |
+| Overlay Loader | CSS | `devsnips/snippets/css-snippets/overlay-loader.css` | Reusable overlay loader snippet. |
+| Parallax Scrolling Effect | CSS | `devsnips/snippets/css-snippets/parallax-scrolling-effect.css` | Reusable parallax scrolling effect snippet. |
+| Prevent Text Selection | CSS | `devsnips/snippets/css-snippets/prevent-text-selection.css` | Reusable prevent text selection snippet. |
+| Pulsing Animation | CSS | `devsnips/snippets/css-snippets/pulsing-animation.css` | Reusable pulsing animation snippet. |
+| Responsive Embed | CSS | `devsnips/snippets/css-snippets/responsive-embed.css` | Reusable responsive embed snippet. |
+| Responsive Grid System | CSS | `devsnips/snippets/css-snippets/responsive-grid-system.css` | Reusable responsive grid system snippet. |
+| Responsive Hiding Utility | CSS | `devsnips/snippets/css-snippets/responsive-hiding-utility.css` | Reusable responsive hiding utility snippet. |
+| Responsive Two Column Layout | CSS | `devsnips/snippets/css-snippets/responsive-two-column-layout.html` | Reusable responsive two column layout snippet. |
+| Responsive Video Container | CSS | `devsnips/snippets/css-snippets/responsive-video-container.html` | Reusable responsive video container snippet. |
+| Scroll Snap Container | CSS | `devsnips/snippets/css-snippets/scroll-snap-container.css` | Reusable scroll snap container snippet. |
+| Simple Gradient Background | CSS | `devsnips/snippets/css-snippets/simple-gradient-background.css` | Reusable simple gradient background snippet. |
+| Skeleton Loader | CSS | `devsnips/snippets/css-snippets/skeleton-loader.css` | Reusable skeleton loader snippet. |
+| Smooth Scroll Behavior | CSS | `devsnips/snippets/css-snippets/smooth-scroll-behavior.css` | Reusable smooth scroll behavior snippet. |
+| Snippet 01 Flexbox Center | CSS | `devsnips/snippets/css-snippets/snippet-01-flexbox-center.css` | Reusable snippet 01 flexbox center snippet. |
+| Snippet 02 Responsive Grid | CSS | `devsnips/snippets/css-snippets/snippet-02-responsive-grid.css` | Reusable snippet 02 responsive grid snippet. |
+| Snippet 03 Sticky Footer | CSS | `devsnips/snippets/css-snippets/snippet-03-sticky-footer.css` | Reusable snippet 03 sticky footer snippet. |
+| Snippet 04 Equal Height Cards | CSS | `devsnips/snippets/css-snippets/snippet-04-equal-height-cards.css` | Reusable snippet 04 equal height cards snippet. |
+| Snippet 05 Fluid Typography | CSS | `devsnips/snippets/css-snippets/snippet-05-fluid-typography.css` | Reusable snippet 05 fluid typography snippet. |
+| Snippet 06 Responsive Container | CSS | `devsnips/snippets/css-snippets/snippet-06-responsive-container.css` | Reusable snippet 06 responsive container snippet. |
+| Snippet 07 Split Screen | CSS | `devsnips/snippets/css-snippets/snippet-07-split-screen.css` | Reusable snippet 07 split screen snippet. |
+| Snippet 08 Masonry Layout | CSS | `devsnips/snippets/css-snippets/snippet-08-masonry-layout.css` | Reusable snippet 08 masonry layout snippet. |
+| Snippet 09 Aspect Ratio | CSS | `devsnips/snippets/css-snippets/snippet-09-aspect-ratio.css` | Reusable snippet 09 aspect ratio snippet. |
+| Snippet 10 Sticky Sidebar | CSS | `devsnips/snippets/css-snippets/snippet-10-sticky-sidebar.css` | Reusable snippet 10 sticky sidebar snippet. |
+| Snippet 11 Hamburger Menu Animation | CSS | `devsnips/snippets/css-snippets/snippet-11-hamburger-menu-animation.css` | Reusable snippet 11 hamburger menu animation snippet. |
+| Snippet 12 Hover Dropdown | CSS | `devsnips/snippets/css-snippets/snippet-12-hover-dropdown.css` | Reusable snippet 12 hover dropdown snippet. |
+| Snippet 13 Animated Underline | CSS | `devsnips/snippets/css-snippets/snippet-13-animated-underline.css` | Reusable snippet 13 animated underline snippet. |
+| Snippet 14 Sticky Nav | CSS | `devsnips/snippets/css-snippets/snippet-14-sticky-nav.css` | Reusable snippet 14 sticky nav snippet. |
+| Snippet 15 Mobile Bottom Nav | CSS | `devsnips/snippets/css-snippets/snippet-15-mobile-bottom-nav.css` | Reusable snippet 15 mobile bottom nav snippet. |
+| Snippet 16 Gradient Button | CSS | `devsnips/snippets/css-snippets/snippet-16-gradient-button.css` | Reusable snippet 16 gradient button snippet. |
+| Snippet 17 Icon Sidebar | CSS | `devsnips/snippets/css-snippets/snippet-17-icon-sidebar.css` | Reusable snippet 17 icon sidebar snippet. |
+| Snippet 18 Css Tabs | CSS | `devsnips/snippets/css-snippets/snippet-18-css-tabs.css` | Reusable snippet 18 css tabs snippet. |
+| Snippet 19 Sliding Indicator | CSS | `devsnips/snippets/css-snippets/snippet-19-sliding-indicator.css` | Reusable snippet 19 sliding indicator snippet. |
+| Snippet 20 Glassmorphism Nav | CSS | `devsnips/snippets/css-snippets/snippet-20-glassmorphism-nav.css` | Reusable snippet 20 glassmorphism nav snippet. |
+| Snippet 21 Neumorphic Button | CSS | `devsnips/snippets/css-snippets/snippet-21-neumorphic-button.css` | Reusable snippet 21 neumorphic button snippet. |
+| Snippet 22 Ripple Effect | CSS | `devsnips/snippets/css-snippets/snippet-22-ripple-effect.css` | Reusable snippet 22 ripple effect snippet. |
+| Snippet 23 Fab Animation | CSS | `devsnips/snippets/css-snippets/snippet-23-fab-animation.css` | Reusable snippet 23 fab animation snippet. |
+| Snippet 24 3D Press Button | CSS | `devsnips/snippets/css-snippets/snippet-24-3d-press-button.css` | Reusable snippet 24 3d press button snippet. |
+| Springy Easing Function | CSS | `devsnips/snippets/css-snippets/springy-easing-function.css` | Reusable springy easing function snippet. |
+| Sticky Footer | CSS | `devsnips/snippets/css-snippets/sticky-footer.html` | Reusable sticky footer snippet. |
+| Sticky Header | CSS | `devsnips/snippets/css-snippets/sticky-header.html` | Reusable sticky header snippet. |
+| Subgrid Layout | CSS | `devsnips/snippets/css-snippets/subgrid-layout.css` | Reusable subgrid layout snippet. |
+| Text Wrap Balance | CSS | `devsnips/snippets/css-snippets/text-wrap-balance.css` | Reusable text wrap balance snippet. |
+| Toggle Switch | CSS | `devsnips/snippets/css-snippets/toggle-switch.html` | Reusable toggle switch snippet. |
+| Tooltip | CSS | `devsnips/snippets/css-snippets/tooltip.html` | Reusable tooltip snippet. |
+| Truncate Text Ellipsis | CSS | `devsnips/snippets/css-snippets/truncate-text-ellipsis.css` | Reusable truncate text ellipsis snippet. |
+| Typing Caret Animation | CSS | `devsnips/snippets/css-snippets/typing-caret-animation.css` | Reusable typing caret animation snippet. |
+| Underline Hover Link | CSS | `devsnips/snippets/css-snippets/underline-hover-link.html` | Reusable underline hover link snippet. |
+| View Transitions Fade | CSS | `devsnips/snippets/css-snippets/view-transitions-fade.css` | Reusable view transitions fade snippet. |
+| Visually Hidden | CSS | `devsnips/snippets/css-snippets/visually-hidden.css` | Reusable visually hidden snippet. |
+| Wavy Underline Text | CSS | `devsnips/snippets/css-snippets/wavy-underline-text.html` | Reusable wavy underline text snippet. |
+| 3D Button Effect | HTML | `devsnips/snippets/html-snippets/3d-button-effect.html` | Reusable 3d button effect snippet. |
+| 3D Text Effect | HTML | `devsnips/snippets/html-snippets/3d-text-effect.html` | Reusable 3d text effect snippet. |
+| 404 Not Found Page | HTML | `devsnips/snippets/html-snippets/404-not-found-page.html` | Reusable 404 not found page snippet. |
+| Abbr Element | HTML | `devsnips/snippets/html-snippets/abbr-element.html` | Reusable abbr element snippet. |
+| Accessible Image | HTML | `devsnips/snippets/html-snippets/accessible-image.html` | Reusable accessible image snippet. |
+| Accordion Faq Layout | HTML | `devsnips/snippets/html-snippets/accordion-faq-layout.html` | Reusable accordion faq layout snippet. |
+| Action Buttons | HTML | `devsnips/snippets/html-snippets/action-buttons.html` | Reusable action buttons snippet. |
+| Address Tag | HTML | `devsnips/snippets/html-snippets/address-tag.html` | Reusable address tag snippet. |
+| Alert Messages | HTML | `devsnips/snippets/html-snippets/alert-messages.html` | Reusable alert messages snippet. |
+| Animated Gradient Background | HTML | `devsnips/snippets/html-snippets/animated-gradient-background.html` | Reusable animated gradient background snippet. |
+| Audio Embed | HTML | `devsnips/snippets/html-snippets/audio-embed.html` | Reusable audio embed snippet. |
+| Back To Top Button | HTML | `devsnips/snippets/html-snippets/back-to-top-button.html` | Reusable back to top button snippet. |
+| Basic Navbar | HTML | `devsnips/snippets/html-snippets/basic-navbar.html` | Reusable basic navbar snippet. |
+| Bdi Element | HTML | `devsnips/snippets/html-snippets/bdi-element.html` | Reusable bdi element snippet. |
+| Blockquote Citation | HTML | `devsnips/snippets/html-snippets/blockquote-citation.html` | Reusable blockquote citation snippet. |
+| Blockquote With Cite | HTML | `devsnips/snippets/html-snippets/blockquote-with-cite.html` | Reusable blockquote with cite snippet. |
+| Blog Post Card | HTML | `devsnips/snippets/html-snippets/blog-post-card.html` | Reusable blog post card snippet. |
+| Bottom Navigation | HTML | `devsnips/snippets/html-snippets/bottom-navigation.html` | Reusable bottom navigation snippet. |
+| Bouncing Loader | HTML | `devsnips/snippets/html-snippets/bouncing-loader.html` | Reusable bouncing loader snippet. |
+| Breadcrumbs Navigation | HTML | `devsnips/snippets/html-snippets/breadcrumbs-navigation.html` | Reusable breadcrumbs navigation snippet. |
+| Calendar Widget | HTML | `devsnips/snippets/html-snippets/calendar-widget.html` | Reusable calendar widget snippet. |
+| Canvas Element | HTML | `devsnips/snippets/html-snippets/canvas-element.html` | Reusable canvas element snippet. |
+| Carousel | HTML | `devsnips/snippets/html-snippets/carousel.html` | Reusable carousel snippet. |
+| Centered Website | HTML | `devsnips/snippets/html-snippets/centered-website.html` | Reusable centered website snippet. |
+| Checkbox Group | HTML | `devsnips/snippets/html-snippets/checkbox-group.html` | Reusable checkbox group snippet. |
+| Circular Menu | HTML | `devsnips/snippets/html-snippets/circular-menu.html` | Reusable circular menu snippet. |
+| Circular Progress Bar | HTML | `devsnips/snippets/html-snippets/circular-progress-bar.html` | Reusable circular progress bar snippet. |
+| Code Block | HTML | `devsnips/snippets/html-snippets/code-block.html` | Reusable code block snippet. |
+| Collapsible | HTML | `devsnips/snippets/html-snippets/collapsible.html` | Reusable collapsible snippet. |
+| Collapsible Accordion | HTML | `devsnips/snippets/html-snippets/collapsible-accordion.html` | Reusable collapsible accordion snippet. |
+| Color Picker | HTML | `devsnips/snippets/html-snippets/color-picker.html` | Reusable color picker snippet. |
+| Coming Soon Page | HTML | `devsnips/snippets/html-snippets/coming-soon-page.html` | Reusable coming soon page snippet. |
+| Contact Chip | HTML | `devsnips/snippets/html-snippets/contact-chip.html` | Reusable contact chip snippet. |
+| Contact Form | HTML | `devsnips/snippets/html-snippets/contact-form.html` | Reusable contact form snippet. |
+| Contact Form Basic | HTML | `devsnips/snippets/html-snippets/contact-form-basic.html` | Reusable contact form basic snippet. |
+| Content Editable | HTML | `devsnips/snippets/html-snippets/content-editable.html` | Reusable content editable snippet. |
+| Cookie Consent Banner | HTML | `devsnips/snippets/html-snippets/cookie-consent-banner.html` | Reusable cookie consent banner snippet. |
+| Corner Ribbon | HTML | `devsnips/snippets/html-snippets/corner-ribbon.html` | Reusable corner ribbon snippet. |
+| Countdown Timer | HTML | `devsnips/snippets/html-snippets/countdown-timer.html` | Reusable countdown timer snippet. |
+| Creative Image Hover | HTML | `devsnips/snippets/html-snippets/creative-image-hover.html` | Reusable creative image hover snippet. |
+| Custom Scrollbar | HTML | `devsnips/snippets/html-snippets/custom-scrollbar.html` | Reusable custom scrollbar snippet. |
+| Cutout Text Effect | HTML | `devsnips/snippets/html-snippets/cutout-text-effect.html` | Reusable cutout text effect snippet. |
+| Datalist Autocomplete | HTML | `devsnips/snippets/html-snippets/datalist-autocomplete.html` | Reusable datalist autocomplete snippet. |
+| Definition List | HTML | `devsnips/snippets/html-snippets/definition-list.html` | Reusable definition list snippet. |
+| Details Summary | HTML | `devsnips/snippets/html-snippets/details-summary.html` | Reusable details summary snippet. |
+| Device Mockups | HTML | `devsnips/snippets/html-snippets/device-mockups.html` | Reusable device mockups snippet. |
+| Diagonal Background | HTML | `devsnips/snippets/html-snippets/diagonal-background.html` | Reusable diagonal background snippet. |
+| Dialog Element | HTML | `devsnips/snippets/html-snippets/dialog-element.html` | Reusable dialog element snippet. |
+| Disabled Input | HTML | `devsnips/snippets/html-snippets/disabled-input.html` | Reusable disabled input snippet. |
+| Download Button | HTML | `devsnips/snippets/html-snippets/download-button.html` | Reusable download button snippet. |
+| Draggable Element | HTML | `devsnips/snippets/html-snippets/draggable-element.html` | Reusable draggable element snippet. |
+| Dropdown Menu | HTML | `devsnips/snippets/html-snippets/dropdown-menu.html` | Reusable dropdown menu snippet. |
+| Fade In Effect | HTML | `devsnips/snippets/html-snippets/fade-in-effect.html` | Reusable fade in effect snippet. |
+| Favicon Link | HTML | `devsnips/snippets/html-snippets/favicon-link.html` | Reusable favicon link snippet. |
+| Fieldset Legend | HTML | `devsnips/snippets/html-snippets/fieldset-legend.html` | Reusable fieldset legend snippet. |
+| Figure Figcaption | HTML | `devsnips/snippets/html-snippets/figure-figcaption.html` | Reusable figure figcaption snippet. |
+| Figure With Figcaption | HTML | `devsnips/snippets/html-snippets/figure-with-figcaption.html` | Reusable figure with figcaption snippet. |
+| File Upload Input | HTML | `devsnips/snippets/html-snippets/file-upload-input.html` | Reusable file upload input snippet. |
+| Filter List | HTML | `devsnips/snippets/html-snippets/filter-list.html` | Reusable filter list snippet. |
+| Fixed Header On Scroll | HTML | `devsnips/snippets/html-snippets/fixed-header-on-scroll.html` | Reusable fixed header on scroll snippet. |
+| Fixed Sidebar | HTML | `devsnips/snippets/html-snippets/fixed-sidebar.html` | Reusable fixed sidebar snippet. |
+| Flipping Card | HTML | `devsnips/snippets/html-snippets/flipping-card.html` | Reusable flipping card snippet. |
+| Fluid Grid | HTML | `devsnips/snippets/html-snippets/fluid-grid.html` | Reusable fluid grid snippet. |
+| Footer | HTML | `devsnips/snippets/html-snippets/footer.html` | Reusable footer snippet. |
+| Four Column Layout | HTML | `devsnips/snippets/html-snippets/four-column-layout.html` | Reusable four column layout snippet. |
+| Full Page Tabs | HTML | `devsnips/snippets/html-snippets/full-page-tabs.html` | Reusable full page tabs snippet. |
+| Full Screen Search | HTML | `devsnips/snippets/html-snippets/full-screen-search.html` | Reusable full screen search snippet. |
+| Full Width Image | HTML | `devsnips/snippets/html-snippets/full-width-image.html` | Reusable full width image snippet. |
+| Gelatine Animation | HTML | `devsnips/snippets/html-snippets/gelatine-animation.html` | Reusable gelatine animation snippet. |
+| Glowing Icon | HTML | `devsnips/snippets/html-snippets/glowing-icon.html` | Reusable glowing icon snippet. |
+| Gradient Text | HTML | `devsnips/snippets/html-snippets/gradient-text.html` | Reusable gradient text snippet. |
+| Hamburger Menu | HTML | `devsnips/snippets/html-snippets/hamburger-menu.html` | Reusable hamburger menu snippet. |
+| Header | HTML | `devsnips/snippets/html-snippets/header.html` | Reusable header snippet. |
+| Heartbeat Animation | HTML | `devsnips/snippets/html-snippets/heartbeat-animation.html` | Reusable heartbeat animation snippet. |
+| Hidden Attribute | HTML | `devsnips/snippets/html-snippets/hidden-attribute.html` | Reusable hidden attribute snippet. |
+| Holy Grail Layout | HTML | `devsnips/snippets/html-snippets/holy-grail-layout.html` | Reusable holy grail layout snippet. |
+| Horizontal Rule | HTML | `devsnips/snippets/html-snippets/horizontal-rule.html` | Reusable horizontal rule snippet. |
+| Html5 Audio Player | HTML | `devsnips/snippets/html-snippets/html5-audio-player.html` | Reusable html5 audio player snippet. |
+| Html5 Boilerplate | HTML | `devsnips/snippets/html-snippets/html5-boilerplate.html` | Reusable html5 boilerplate snippet. |
+| Html5 Video Player | HTML | `devsnips/snippets/html-snippets/html5-video-player.html` | Reusable html5 video player snippet. |
+| Iframe Embed | HTML | `devsnips/snippets/html-snippets/iframe-embed.html` | Reusable iframe embed snippet. |
+| Image Map | HTML | `devsnips/snippets/html-snippets/image-map.html` | Reusable image map snippet. |
+| Image Overlay Effect | HTML | `devsnips/snippets/html-snippets/image-overlay-effect.html` | Reusable image overlay effect snippet. |
+| Image Zoom On Hover | HTML | `devsnips/snippets/html-snippets/image-zoom-on-hover.html` | Reusable image zoom on hover snippet. |
+| Input Pattern Validation | HTML | `devsnips/snippets/html-snippets/input-pattern-validation.html` | Reusable input pattern validation snippet. |
+| Input With Min Max | HTML | `devsnips/snippets/html-snippets/input-with-min-max.html` | Reusable input with min max snippet. |
+| Jumbotron | HTML | `devsnips/snippets/html-snippets/jumbotron.html` | Reusable jumbotron snippet. |
+| Keyboard Input | HTML | `devsnips/snippets/html-snippets/keyboard-input.html` | Reusable keyboard input snippet. |
+| List Group | HTML | `devsnips/snippets/html-snippets/list-group.html` | Reusable list group snippet. |
+| Loader | HTML | `devsnips/snippets/html-snippets/loader.html` | Reusable loader snippet. |
+| Login Form | HTML | `devsnips/snippets/html-snippets/login-form.html` | Reusable login form snippet. |
+| Main Element | HTML | `devsnips/snippets/html-snippets/main-element.html` | Reusable main element snippet. |
+| Mark Text | HTML | `devsnips/snippets/html-snippets/mark-text.html` | Reusable mark text snippet. |
+| Media Object | HTML | `devsnips/snippets/html-snippets/media-object.html` | Reusable media object snippet. |
+| Mega Menu | HTML | `devsnips/snippets/html-snippets/mega-menu.html` | Reusable mega menu snippet. |
+| Meter Element | HTML | `devsnips/snippets/html-snippets/meter-element.html` | Reusable meter element snippet. |
+| Mixed Column Layout | HTML | `devsnips/snippets/html-snippets/mixed-column-layout.html` | Reusable mixed column layout snippet. |
+| Modal Box | HTML | `devsnips/snippets/html-snippets/modal-box.html` | Reusable modal box snippet. |
+| Modal Dialog | HTML | `devsnips/snippets/html-snippets/modal-dialog.html` | Reusable modal dialog snippet. |
+| Multi Select Dropdown | HTML | `devsnips/snippets/html-snippets/multi-select-dropdown.html` | Reusable multi select dropdown snippet. |
+| Neon Text | HTML | `devsnips/snippets/html-snippets/neon-text.html` | Reusable neon text snippet. |
+| Newsletter Signup Form | HTML | `devsnips/snippets/html-snippets/newsletter-signup-form.html` | Reusable newsletter signup form snippet. |
+| Notification Badge | HTML | `devsnips/snippets/html-snippets/notification-badge.html` | Reusable notification badge snippet. |
+| One Page Scrolling | HTML | `devsnips/snippets/html-snippets/one-page-scrolling.html` | Reusable one page scrolling snippet. |
+| Output Element | HTML | `devsnips/snippets/html-snippets/output-element.html` | Reusable output element snippet. |
+| Pagination Component | HTML | `devsnips/snippets/html-snippets/pagination-component.html` | Reusable pagination component snippet. |
+| Parallax Scrolling Effect | HTML | `devsnips/snippets/html-snippets/parallax-scrolling-effect.html` | Reusable parallax scrolling effect snippet. |
+| Perfectly Centered Div | HTML | `devsnips/snippets/html-snippets/perfectly-centered-div.html` | Reusable perfectly centered div snippet. |
+| Picture Element | HTML | `devsnips/snippets/html-snippets/picture-element.html` | Reusable picture element snippet. |
+| Pills | HTML | `devsnips/snippets/html-snippets/pills.html` | Reusable pills snippet. |
+| Pop Up Image | HTML | `devsnips/snippets/html-snippets/pop-up-image.html` | Reusable pop up image snippet. |
+| Popup Chat Window | HTML | `devsnips/snippets/html-snippets/popup-chat-window.html` | Reusable popup chat window snippet. |
+| Portfolio Gallery | HTML | `devsnips/snippets/html-snippets/portfolio-gallery.html` | Reusable portfolio gallery snippet. |
+| Pricing Card | HTML | `devsnips/snippets/html-snippets/pricing-card.html` | Reusable pricing card snippet. |
+| Pricing Table | HTML | `devsnips/snippets/html-snippets/pricing-table.html` | Reusable pricing table snippet. |
+| Product Card | HTML | `devsnips/snippets/html-snippets/product-card.html` | Reusable product card snippet. |
+| Profile Card | HTML | `devsnips/snippets/html-snippets/profile-card.html` | Reusable profile card snippet. |
+| Progress Bar | HTML | `devsnips/snippets/html-snippets/progress-bar.html` | Reusable progress bar snippet. |
+| Progress Steps | HTML | `devsnips/snippets/html-snippets/progress-steps.html` | Reusable progress steps snippet. |
+| Pulsing Button | HTML | `devsnips/snippets/html-snippets/pulsing-button.html` | Reusable pulsing button snippet. |
+| Radio Button Group | HTML | `devsnips/snippets/html-snippets/radio-button-group.html` | Reusable radio button group snippet. |
+| Range Input | HTML | `devsnips/snippets/html-snippets/range-input.html` | Reusable range input snippet. |
+| Range Slider | HTML | `devsnips/snippets/html-snippets/range-slider.html` | Reusable range slider snippet. |
+| Readonly Input | HTML | `devsnips/snippets/html-snippets/readonly-input.html` | Reusable readonly input snippet. |
+| Registration Form | HTML | `devsnips/snippets/html-snippets/registration-form.html` | Reusable registration form snippet. |
+| Responsive Form | HTML | `devsnips/snippets/html-snippets/responsive-form.html` | Reusable responsive form snippet. |
+| Responsive Image Gallery | HTML | `devsnips/snippets/html-snippets/responsive-image-gallery.html` | Reusable responsive image gallery snippet. |
+| Responsive Picture | HTML | `devsnips/snippets/html-snippets/responsive-picture.html` | Reusable responsive picture snippet. |
+| Responsive Pricing Grid | HTML | `devsnips/snippets/html-snippets/responsive-pricing-grid.html` | Reusable responsive pricing grid snippet. |
+| Rubber Band Animation | HTML | `devsnips/snippets/html-snippets/rubber-band-animation.html` | Reusable rubber band animation snippet. |
+| Search Input | HTML | `devsnips/snippets/html-snippets/search-input.html` | Reusable search input snippet. |
+| Select Dropdown | HTML | `devsnips/snippets/html-snippets/select-dropdown.html` | Reusable select dropdown snippet. |
+| Select With Optgroup | HTML | `devsnips/snippets/html-snippets/select-with-optgroup.html` | Reusable select with optgroup snippet. |
+| Semantic Layout | HTML | `devsnips/snippets/html-snippets/semantic-layout.html` | Reusable semantic layout snippet. |
+| Side Navigation | HTML | `devsnips/snippets/html-snippets/side-navigation.html` | Reusable side navigation snippet. |
+| Simple Footer | HTML | `devsnips/snippets/html-snippets/simple-footer.html` | Reusable simple footer snippet. |
+| Simple Navigation Menu | HTML | `devsnips/snippets/html-snippets/simple-navigation-menu.html` | Reusable simple navigation menu snippet. |
+| Simple Ordered List | HTML | `devsnips/snippets/html-snippets/simple-ordered-list.html` | Reusable simple ordered list snippet. |
+| Simple Table | HTML | `devsnips/snippets/html-snippets/simple-table.html` | Reusable simple table snippet. |
+| Simple Unordered List | HTML | `devsnips/snippets/html-snippets/simple-unordered-list.html` | Reusable simple unordered list snippet. |
+| Skeleton Loader | HTML | `devsnips/snippets/html-snippets/skeleton-loader.html` | Reusable skeleton loader snippet. |
+| Skewed Button | HTML | `devsnips/snippets/html-snippets/skewed-button.html` | Reusable skewed button snippet. |
+| Skill Bar | HTML | `devsnips/snippets/html-snippets/skill-bar.html` | Reusable skill bar snippet. |
+| Skip Link | HTML | `devsnips/snippets/html-snippets/skip-link.html` | Reusable skip link snippet. |
+| Slide In From Left Effect | HTML | `devsnips/snippets/html-snippets/slide-in-from-left-effect.html` | Reusable slide in from left effect snippet. |
+| Slide In From Right Effect | HTML | `devsnips/snippets/html-snippets/slide-in-from-right-effect.html` | Reusable slide in from right effect snippet. |
+| Slide In Overlay | HTML | `devsnips/snippets/html-snippets/slide-in-overlay.html` | Reusable slide in overlay snippet. |
+| Snippet 01 Responsive Navbar | HTML | `devsnips/snippets/html-snippets/snippet-01-responsive-navbar.html` | Reusable snippet 01 responsive navbar snippet. |
+| Snippet 02 Sticky Header | HTML | `devsnips/snippets/html-snippets/snippet-02-sticky-header.html` | Reusable snippet 02 sticky header snippet. |
+| Snippet 03 Mobile Dropdown | HTML | `devsnips/snippets/html-snippets/snippet-03-mobile-dropdown.html` | Reusable snippet 03 mobile dropdown snippet. |
+| Snippet 04 Accordion Faq | HTML | `devsnips/snippets/html-snippets/snippet-04-accordion-faq.html` | Reusable snippet 04 accordion faq snippet. |
+| Snippet 05 Tabbed Content | HTML | `devsnips/snippets/html-snippets/snippet-05-tabbed-content.html` | Reusable snippet 05 tabbed content snippet. |
+| Snippet 06 Dark Mode Toggle | HTML | `devsnips/snippets/html-snippets/snippet-06-dark-mode-toggle.html` | Reusable snippet 06 dark mode toggle snippet. |
+| Snippet 07 Device Optimized Modal | HTML | `devsnips/snippets/html-snippets/snippet-07-device-optimized-modal.html` | Reusable snippet 07 device optimized modal snippet. |
+| Snippet 08 Toast Notification | HTML | `devsnips/snippets/html-snippets/snippet-08-toast-notification.html` | Reusable snippet 08 toast notification snippet. |
+| Snippet 09 Floating Action Button | HTML | `devsnips/snippets/html-snippets/snippet-09-floating-action-button.html` | Reusable snippet 09 floating action button snippet. |
+| Snippet 10 Breadcrumb Nav | HTML | `devsnips/snippets/html-snippets/snippet-10-breadcrumb-nav.html` | Reusable snippet 10 breadcrumb nav snippet. |
+| Snippet 11 Search Autocomplete | HTML | `devsnips/snippets/html-snippets/snippet-11-search-autocomplete.html` | Reusable snippet 11 search autocomplete snippet. |
+| Snippet 12 Inline Form | HTML | `devsnips/snippets/html-snippets/snippet-12-inline-form.html` | Reusable snippet 12 inline form snippet. |
+| Snippet 13 Contact Form | HTML | `devsnips/snippets/html-snippets/snippet-13-contact-form.html` | Reusable snippet 13 contact form snippet. |
+| Snippet 14 Newsletter Signup | HTML | `devsnips/snippets/html-snippets/snippet-14-newsletter-signup.html` | Reusable snippet 14 newsletter signup snippet. |
+| Snippet 15 Password Visibility Toggle | HTML | `devsnips/snippets/html-snippets/snippet-15-password-visibility-toggle.html` | Reusable snippet 15 password visibility toggle snippet. |
+| Snippet 16 File Upload Input | HTML | `devsnips/snippets/html-snippets/snippet-16-file-upload-input.html` | Reusable snippet 16 file upload input snippet. |
+| Snippet 17 Rating Stars | HTML | `devsnips/snippets/html-snippets/snippet-17-rating-stars.html` | Reusable snippet 17 rating stars snippet. |
+| Snippet 18 Date Time Picker | HTML | `devsnips/snippets/html-snippets/snippet-18-date-time-picker.html` | Reusable snippet 18 date time picker snippet. |
+| Social Buttons | HTML | `devsnips/snippets/html-snippets/social-buttons.html` | Reusable social buttons snippet. |
+| Social Media Icons | HTML | `devsnips/snippets/html-snippets/social-media-icons.html` | Reusable social media icons snippet. |
+| Social Media Share Links | HTML | `devsnips/snippets/html-snippets/social-media-share-links.html` | Reusable social media share links snippet. |
+| Spellcheck Attribute | HTML | `devsnips/snippets/html-snippets/spellcheck-attribute.html` | Reusable spellcheck attribute snippet. |
+| Split Button | HTML | `devsnips/snippets/html-snippets/split-button.html` | Reusable split button snippet. |
+| Split Screen | HTML | `devsnips/snippets/html-snippets/split-screen.html` | Reusable split screen snippet. |
+| Staff Card | HTML | `devsnips/snippets/html-snippets/staff-card.html` | Reusable staff card snippet. |
+| Sticky Notes | HTML | `devsnips/snippets/html-snippets/sticky-notes.html` | Reusable sticky notes snippet. |
+| Sticky Social Bar | HTML | `devsnips/snippets/html-snippets/sticky-social-bar.html` | Reusable sticky social bar snippet. |
+| Subscription Form | HTML | `devsnips/snippets/html-snippets/subscription-form.html` | Reusable subscription form snippet. |
+| Svg Circle | HTML | `devsnips/snippets/html-snippets/svg-circle.html` | Reusable svg circle snippet. |
+| Swing Animation | HTML | `devsnips/snippets/html-snippets/swing-animation.html` | Reusable swing animation snippet. |
+| Table Caption | HTML | `devsnips/snippets/html-snippets/table-caption.html` | Reusable table caption snippet. |
+| Table Header Body Footer | HTML | `devsnips/snippets/html-snippets/table-header-body-footer.html` | Reusable table header body footer snippet. |
+| Table Merged Cells | HTML | `devsnips/snippets/html-snippets/table-merged-cells.html` | Reusable table merged cells snippet. |
+| Table Scope | HTML | `devsnips/snippets/html-snippets/table-scope.html` | Reusable table scope snippet. |
+| Tabs | HTML | `devsnips/snippets/html-snippets/tabs.html` | Reusable tabs snippet. |
+| Tada Animation | HTML | `devsnips/snippets/html-snippets/tada-animation.html` | Reusable tada animation snippet. |
+| Template Element | HTML | `devsnips/snippets/html-snippets/template-element.html` | Reusable template element snippet. |
+| Testimonial Slider | HTML | `devsnips/snippets/html-snippets/testimonial-slider.html` | Reusable testimonial slider snippet. |
+| Text Reveal On Hover | HTML | `devsnips/snippets/html-snippets/text-reveal-on-hover.html` | Reusable text reveal on hover snippet. |
+| Text With Background Image | HTML | `devsnips/snippets/html-snippets/text-with-background-image.html` | Reusable text with background image snippet. |
+| Textarea Label | HTML | `devsnips/snippets/html-snippets/textarea-label.html` | Reusable textarea label snippet. |
+| Three Column Layout | HTML | `devsnips/snippets/html-snippets/three-column-layout.html` | Reusable three column layout snippet. |
+| Time Element | HTML | `devsnips/snippets/html-snippets/time-element.html` | Reusable time element snippet. |
+| Timeline | HTML | `devsnips/snippets/html-snippets/timeline.html` | Reusable timeline snippet. |
+| Toast Notification Markup | HTML | `devsnips/snippets/html-snippets/toast-notification-markup.html` | Reusable toast notification markup snippet. |
+| Tooltip Text | HTML | `devsnips/snippets/html-snippets/tooltip-text.html` | Reusable tooltip text snippet. |
+| Top Navigation | HTML | `devsnips/snippets/html-snippets/top-navigation.html` | Reusable top navigation snippet. |
+| Two Column Layout | HTML | `devsnips/snippets/html-snippets/two-column-layout.html` | Reusable two column layout snippet. |
+| Typing Effect | HTML | `devsnips/snippets/html-snippets/typing-effect.html` | Reusable typing effect snippet. |
+| User Rating | HTML | `devsnips/snippets/html-snippets/user-rating.html` | Reusable user rating snippet. |
+| Vertical Menu | HTML | `devsnips/snippets/html-snippets/vertical-menu.html` | Reusable vertical menu snippet. |
+| Video Background | HTML | `devsnips/snippets/html-snippets/video-background.html` | Reusable video background snippet. |
+| Weather Widget | HTML | `devsnips/snippets/html-snippets/weather-widget.html` | Reusable weather widget snippet. |
+| Wobble Animation | HTML | `devsnips/snippets/html-snippets/wobble-animation.html` | Reusable wobble animation snippet. |
+| Accessible Skip Link | JS | `devsnips/snippets/js-snippets/Accessible Skip Link.html` | Reusable accessible skip link snippet. |
+| Accordion Panel | JS | `devsnips/snippets/js-snippets/accordion-panel.html` | Reusable accordion panel snippet. |
+| Average Of Numbers | JS | `devsnips/snippets/js-snippets/average-of-numbers.js` | Reusable average of numbers snippet. |
+| Capitalize String | JS | `devsnips/snippets/js-snippets/capitalize-string.js` | Reusable capitalize string snippet. |
+| Character Counter | JS | `devsnips/snippets/js-snippets/character-counter.html` | Reusable character counter snippet. |
+| Check For Touch Support | JS | `devsnips/snippets/js-snippets/check-for-touch-support.js` | Reusable check for touch support snippet. |
+| Clipboard Copy Helper | JS | `devsnips/snippets/js-snippets/clipboard-copy-helper.js` | Reusable clipboard copy helper snippet. |
+| Clone Array | JS | `devsnips/snippets/js-snippets/clone-array.js` | Reusable clone array snippet. |
+| Convert Array Of Strings To Uppercase | JS | `devsnips/snippets/js-snippets/convert-array-of-strings-to-uppercase.js` | Reusable convert array of strings to uppercase snippet. |
+| Copy Text To Clipboard | JS | `devsnips/snippets/js-snippets/copy-text-to-clipboard.js` | Reusable copy text to clipboard snippet. |
+| Copy To Clipboard | JS | `devsnips/snippets/js-snippets/copy-to-clipboard.html` | Reusable copy to clipboard snippet. |
+| Css Toggle Switch | JS | `devsnips/snippets/js-snippets/CSS Toggle Switch.html` | Reusable css toggle switch snippet. |
+| Dark Mode Toggle | JS | `devsnips/snippets/js-snippets/dark-mode-toggle.html` | Reusable dark mode toggle snippet. |
+| Day Of Year | JS | `devsnips/snippets/js-snippets/day-of-year.js` | Reusable day of year snippet. |
+| Debounce Utility | JS | `devsnips/snippets/js-snippets/debounce-utility.js` | Reusable debounce utility snippet. |
+| Debounced Input Handler (Js) | JS | `devsnips/snippets/js-snippets/Debounced Input Handler (JS).js` | Reusable debounced input handler (js) snippet. |
+| Deep Clone Object | JS | `devsnips/snippets/js-snippets/deep-clone-object.js` | Reusable deep clone object snippet. |
+| Fetch Wrapper With Timeout | JS | `devsnips/snippets/js-snippets/Fetch Wrapper with Timeout.js` | Reusable fetch wrapper with timeout snippet. |
+| Flatten Array | JS | `devsnips/snippets/js-snippets/flatten-array.js` | Reusable flatten array snippet. |
+| Focus Trap (Modal) | JS | `devsnips/snippets/js-snippets/Focus Trap (modal).js` | Reusable focus trap (modal) snippet. |
+| Form Validation | JS | `devsnips/snippets/js-snippets/form-validation.html` | Reusable form validation snippet. |
+| Form Validator | JS | `devsnips/snippets/js-snippets/form-validator.js` | Reusable form validator snippet. |
+| Generate Random Hex Color | JS | `devsnips/snippets/js-snippets/generate-random-hex-color.js` | Reusable generate random hex color snippet. |
+| Get Cookie Value | JS | `devsnips/snippets/js-snippets/get-cookie-value.js` | Reusable get cookie value snippet. |
+| Get Current Timestamp | JS | `devsnips/snippets/js-snippets/get-current-timestamp.js` | Reusable get current timestamp snippet. |
+| Get Max From Array | JS | `devsnips/snippets/js-snippets/get-max-from-array.js` | Reusable get max from array snippet. |
+| Get Min From Array | JS | `devsnips/snippets/js-snippets/get-min-from-array.js` | Reusable get min from array snippet. |
+| Get Random Element From Array | JS | `devsnips/snippets/js-snippets/get-random-element-from-array.js` | Reusable get random element from array snippet. |
+| Get Random Number In Range | JS | `devsnips/snippets/js-snippets/get-random-number-in-range.js` | Reusable get random number in range snippet. |
+| Get Time From Date | JS | `devsnips/snippets/js-snippets/get-time-from-date.js` | Reusable get time from date snippet. |
+| Get Unique Values From Array | JS | `devsnips/snippets/js-snippets/get-unique-values-from-array.js` | Reusable get unique values from array snippet. |
+| Get Url Parameters | JS | `devsnips/snippets/js-snippets/get-url-parameters.js` | Reusable get url parameters snippet. |
+| Has Duplicates In Array | JS | `devsnips/snippets/js-snippets/has-duplicates-in-array.js` | Reusable has duplicates in array snippet. |
+| Image Slider | JS | `devsnips/snippets/js-snippets/image-slider.html` | Reusable image slider snippet. |
+| Is Apple Device | JS | `devsnips/snippets/js-snippets/is-apple-device.js` | Reusable is apple device snippet. |
+| Is Array | JS | `devsnips/snippets/js-snippets/is-array.js` | Reusable is array snippet. |
+| Is Array Empty | JS | `devsnips/snippets/js-snippets/is-array-empty.js` | Reusable is array empty snippet. |
+| Is Boolean | JS | `devsnips/snippets/js-snippets/is-boolean.js` | Reusable is boolean snippet. |
+| Is Browser | JS | `devsnips/snippets/js-snippets/is-browser.js` | Reusable is browser snippet. |
+| Is Browser Tab In View | JS | `devsnips/snippets/js-snippets/is-browser-tab-in-view.js` | Reusable is browser tab in view snippet. |
+| Is Date Valid | JS | `devsnips/snippets/js-snippets/is-date-valid.js` | Reusable is date valid snippet. |
+| Is Even | JS | `devsnips/snippets/js-snippets/is-even.js` | Reusable is even snippet. |
+| Is Function | JS | `devsnips/snippets/js-snippets/is-function.js` | Reusable is function snippet. |
+| Is Node | JS | `devsnips/snippets/js-snippets/is-node.js` | Reusable is node snippet. |
+| Is Null | JS | `devsnips/snippets/js-snippets/is-null.js` | Reusable is null snippet. |
+| Is Number | JS | `devsnips/snippets/js-snippets/is-number.js` | Reusable is number snippet. |
+| Is Object | JS | `devsnips/snippets/js-snippets/is-object.js` | Reusable is object snippet. |
+| Is Object Empty | JS | `devsnips/snippets/js-snippets/is-object-empty.js` | Reusable is object empty snippet. |
+| Is Promise | JS | `devsnips/snippets/js-snippets/is-promise.js` | Reusable is promise snippet. |
+| Is String | JS | `devsnips/snippets/js-snippets/is-string.js` | Reusable is string snippet. |
+| Is Undefined | JS | `devsnips/snippets/js-snippets/is-undefined.js` | Reusable is undefined snippet. |
+| Is Valid Json | JS | `devsnips/snippets/js-snippets/is-valid-json.js` | Reusable is valid json snippet. |
+| Is Weekday | JS | `devsnips/snippets/js-snippets/is-weekday.js` | Reusable is weekday snippet. |
+| Is Weekend | JS | `devsnips/snippets/js-snippets/is-weekend.js` | Reusable is weekend snippet. |
+| Lazy Image Loader | JS | `devsnips/snippets/js-snippets/lazy-image-loader.js` | Reusable lazy image loader snippet. |
+| Local Storage Wrapper | JS | `devsnips/snippets/js-snippets/local-storage-wrapper.js` | Reusable local storage wrapper snippet. |
+| Localstorage Json Helpers | JS | `devsnips/snippets/js-snippets/LocalStorage JSON Helpers.js` | Reusable localstorage json helpers snippet. |
+| Modal Popup | JS | `devsnips/snippets/js-snippets/modal-popup.html` | Reusable modal popup snippet. |
+| Progressive Image (Blur Up) | JS | `devsnips/snippets/js-snippets/Progressive Image (blur-up).html` | Reusable progressive image (blur up) snippet. |
+| Redirect To Url | JS | `devsnips/snippets/js-snippets/redirect-to-url.js` | Reusable redirect to url snippet. |
+| Remove Duplicates From Array | JS | `devsnips/snippets/js-snippets/remove-duplicates-from-array.js` | Reusable remove duplicates from array snippet. |
+| Remove Falsy Values From Array | JS | `devsnips/snippets/js-snippets/remove-falsy-values-from-array.js` | Reusable remove falsy values from array snippet. |
+| Remove Html Tags | JS | `devsnips/snippets/js-snippets/remove-html-tags.js` | Reusable remove html tags snippet. |
+| Responsive Sticky Header With Shadow | JS | `devsnips/snippets/js-snippets/Responsive Sticky Header with Shadow.html` | Reusable responsive sticky header with shadow snippet. |
+| Rgb To Hex | JS | `devsnips/snippets/js-snippets/rgb-to-hex.js` | Reusable rgb to hex snippet. |
+| Scroll To Top | JS | `devsnips/snippets/js-snippets/scroll-to-top.html` | Reusable scroll to top snippet. |
+| Scroll To Top Of Page | JS | `devsnips/snippets/js-snippets/scroll-to-top-of-page.js` | Reusable scroll to top of page snippet. |
+| Shuffle Array | JS | `devsnips/snippets/js-snippets/shuffle-array.js` | Reusable shuffle array snippet. |
+| Sum All Numbers In Array | JS | `devsnips/snippets/js-snippets/sum-all-numbers-in-array.js` | Reusable sum all numbers in array snippet. |
+| Tabs Component | JS | `devsnips/snippets/js-snippets/tabs-component.html` | Reusable tabs component snippet. |
+| Toast Notification | JS | `devsnips/snippets/js-snippets/toast-notification.html` | Reusable toast notification snippet. |
+| Toggle Element Visibility | JS | `devsnips/snippets/js-snippets/toggle-element-visibility.js` | Reusable toggle element visibility snippet. |
+| Truncate String | JS | `devsnips/snippets/js-snippets/truncate-string.js` | Reusable truncate string snippet. |

--- a/devsnips/snippets/css-snippets/animated-hamburger-menu.css
+++ b/devsnips/snippets/css-snippets/animated-hamburger-menu.css
@@ -1,0 +1,38 @@
+/*
+Snippet Name: Animated Hamburger Menu
+Description: Three-line hamburger icon transition to close state.
+Author: DevSnips Contributors
+Usage Example: Toggle .is-active on the button to animate to an X icon.
+*/
+
+.hamburger {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  width: 42px;
+  height: 42px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.hamburger span {
+  display: block;
+  width: 24px;
+  height: 2px;
+  background: currentColor;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.hamburger.is-active span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+
+.hamburger.is-active span:nth-child(2) {
+  opacity: 0;
+}
+
+.hamburger.is-active span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}

--- a/devsnips/snippets/css-snippets/dark-mode-css-variables.css
+++ b/devsnips/snippets/css-snippets/dark-mode-css-variables.css
@@ -1,0 +1,23 @@
+/*
+Snippet Name: Dark Mode CSS Variables
+Description: Theme tokens for light and dark mode using custom properties.
+Author: DevSnips Contributors
+Usage Example: Add data-theme="dark" on html/body to activate dark mode variables.
+*/
+
+:root {
+  color-scheme: light dark;
+  --color-bg: #ffffff;
+  --color-surface: #f5f7fb;
+  --color-text: #121417;
+  --color-muted: #64748b;
+  --color-accent: #3b82f6;
+}
+
+[data-theme="dark"] {
+  --color-bg: #0b1020;
+  --color-surface: #111827;
+  --color-text: #f8fafc;
+  --color-muted: #94a3b8;
+  --color-accent: #60a5fa;
+}

--- a/devsnips/snippets/css-snippets/focus-visible-accessibility.css
+++ b/devsnips/snippets/css-snippets/focus-visible-accessibility.css
@@ -1,0 +1,12 @@
+/*
+Snippet Name: Focus Visible Accessibility
+Description: Accessible focus ring styles that appear for keyboard navigation.
+Author: DevSnips Contributors
+Usage Example: Include globally to improve keyboard focus visibility.
+*/
+
+:where(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
+  outline: 3px solid #2563eb;
+  outline-offset: 2px;
+  border-radius: 4px;
+}

--- a/devsnips/snippets/css-snippets/responsive-grid-system.css
+++ b/devsnips/snippets/css-snippets/responsive-grid-system.css
@@ -1,0 +1,24 @@
+/*
+Snippet Name: Responsive Grid System
+Description: Lightweight responsive grid with reusable column span helpers.
+Author: DevSnips Contributors
+Usage Example: Use .grid with .col-span-* classes to build responsive layouts.
+*/
+
+.grid {
+  --grid-gap: 1rem;
+  display: grid;
+  gap: var(--grid-gap);
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+}
+
+.col-span-12 { grid-column: span 12; }
+.col-span-6 { grid-column: span 6; }
+.col-span-4 { grid-column: span 4; }
+.col-span-3 { grid-column: span 3; }
+
+@media (max-width: 768px) {
+  [class*="col-span-"] {
+    grid-column: span 12;
+  }
+}

--- a/devsnips/snippets/html-snippets/accordion-faq-layout.html
+++ b/devsnips/snippets/html-snippets/accordion-faq-layout.html
@@ -1,0 +1,29 @@
+<!--
+Snippet Name: Accordion FAQ Layout
+Description: Semantic FAQ accordion using details/summary elements.
+Author: DevSnips Contributors
+Usage Example: Duplicate each details block to add more FAQ entries.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Accordion FAQ Layout</title>
+  </head>
+  <body>
+    <section aria-labelledby="faq-title">
+      <h2 id="faq-title">Frequently asked questions</h2>
+
+      <details>
+        <summary>How do I use this snippet?</summary>
+        <p>Copy the section and customize text/content for your product.</p>
+      </details>
+
+      <details>
+        <summary>Is this accessible?</summary>
+        <p>Yes, details/summary provides native keyboard and screen reader support.</p>
+      </details>
+    </section>
+  </body>
+</html>

--- a/devsnips/snippets/html-snippets/collapsible-accordion.html
+++ b/devsnips/snippets/html-snippets/collapsible-accordion.html
@@ -1,3 +1,10 @@
+<!--
+Snippet Name: Collapsible Accordion
+Description: Reusable collapsible accordion snippet for frontend projects.
+Author: DevSnips Contributors
+Usage Example: Open `devsnips/snippets/html-snippets/collapsible-accordion.html` and copy the snippet into your project.
+-->
+
 <div class="collapsible-accordion">
   <div class="accordion-item">
     <button class="accordion-header" aria-expanded="false">

--- a/devsnips/snippets/html-snippets/modal-dialog.html
+++ b/devsnips/snippets/html-snippets/modal-dialog.html
@@ -1,0 +1,25 @@
+<!--
+Snippet Name: Modal Dialog
+Description: Accessible modal dialog markup with close button, title, and description.
+Author: DevSnips Contributors
+Usage Example: Include this markup and pair it with your preferred CSS/JS open-close logic.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Modal Dialog Snippet</title>
+  </head>
+  <body>
+    <button type="button" aria-haspopup="dialog" aria-controls="example-modal">Open modal</button>
+
+    <div id="example-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description" hidden>
+      <div>
+        <h2 id="modal-title">Modal title</h2>
+        <p id="modal-description">Use this modal for confirmations, forms, or quick context panels.</p>
+        <button type="button" aria-label="Close modal">Close</button>
+      </div>
+    </div>
+  </body>
+</html>

--- a/devsnips/snippets/html-snippets/pricing-card.html
+++ b/devsnips/snippets/html-snippets/pricing-card.html
@@ -1,0 +1,26 @@
+<!--
+Snippet Name: Pricing Card
+Description: Semantic pricing card with plan name, price, feature list, and CTA.
+Author: DevSnips Contributors
+Usage Example: Place multiple cards in a grid for tiered pricing sections.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pricing Card Snippet</title>
+  </head>
+  <body>
+    <article aria-labelledby="starter-plan-title">
+      <h3 id="starter-plan-title">Starter</h3>
+      <p><strong>$12</strong> / month</p>
+      <ul>
+        <li>Up to 5 projects</li>
+        <li>Email support</li>
+        <li>Community access</li>
+      </ul>
+      <button type="button" aria-label="Choose Starter plan">Choose plan</button>
+    </article>
+  </body>
+</html>

--- a/devsnips/snippets/html-snippets/skeleton-loader.html
+++ b/devsnips/snippets/html-snippets/skeleton-loader.html
@@ -1,0 +1,21 @@
+<!--
+Snippet Name: Skeleton Loader
+Description: Content placeholder structure for loading states.
+Author: DevSnips Contributors
+Usage Example: Pair with skeleton animation CSS to indicate asynchronous loading.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Skeleton Loader</title>
+  </head>
+  <body>
+    <article aria-busy="true" aria-live="polite" aria-label="Loading profile card">
+      <div role="presentation"></div>
+      <div role="presentation"></div>
+      <div role="presentation"></div>
+    </article>
+  </body>
+</html>

--- a/devsnips/snippets/html-snippets/toast-notification-markup.html
+++ b/devsnips/snippets/html-snippets/toast-notification-markup.html
@@ -1,0 +1,24 @@
+<!--
+Snippet Name: Toast Notification Markup
+Description: Non-blocking toast notification container with ARIA live region.
+Author: DevSnips Contributors
+Usage Example: Inject toast messages into the list at runtime with JavaScript.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Toast Notification Markup</title>
+  </head>
+  <body>
+    <section aria-label="Notifications">
+      <ul aria-live="polite" aria-atomic="true">
+        <li role="status">
+          <p>Profile updated successfully.</p>
+          <button type="button" aria-label="Dismiss notification">Dismiss</button>
+        </li>
+      </ul>
+    </section>
+  </body>
+</html>

--- a/devsnips/snippets/js-snippets/Accessible Skip Link.html
+++ b/devsnips/snippets/js-snippets/Accessible Skip Link.html
@@ -1,3 +1,10 @@
+<!--
+Snippet Name: Accessible Skip Link
+Description: Reusable accessible skip link snippet for frontend projects.
+Author: DevSnips Contributors
+Usage Example: Open `devsnips/snippets/js-snippets/Accessible Skip Link.html` and copy the snippet into your project.
+-->
+
 <a href="#main" class="skip-link">Skip to content</a>
 <main id="main">...</main>
 

--- a/devsnips/snippets/js-snippets/CSS Toggle Switch.html
+++ b/devsnips/snippets/js-snippets/CSS Toggle Switch.html
@@ -1,3 +1,10 @@
+<!--
+Snippet Name: Css Toggle Switch
+Description: Reusable css toggle switch snippet for frontend projects.
+Author: DevSnips Contributors
+Usage Example: Open `devsnips/snippets/js-snippets/CSS Toggle Switch.html` and copy the snippet into your project.
+-->
+
 <label class="switch"><input type="checkbox"><span class="track"></span></label>
 
 

--- a/devsnips/snippets/js-snippets/Debounced Input Handler (JS).js
+++ b/devsnips/snippets/js-snippets/Debounced Input Handler (JS).js
@@ -1,3 +1,10 @@
+/**
+ * Snippet Name: Debounced Input Handler (Js)
+ * Description: Reusable debounced input handler (js) JavaScript utility snippet for frontend projects.
+ * Author: DevSnips Contributors
+ * Usage Example: Open `devsnips/snippets/js-snippets/Debounced Input Handler (JS).js` and copy the snippet into your project.
+ */
+
 function debounce(fn,ms=300){let t;return(...args)=>{clearTimeout(t);t=setTimeout(()=>fn(...args),ms);};}
 
 

--- a/devsnips/snippets/js-snippets/Fetch Wrapper with Timeout.js
+++ b/devsnips/snippets/js-snippets/Fetch Wrapper with Timeout.js
@@ -1,3 +1,10 @@
+/**
+ * Snippet Name: Fetch Wrapper With Timeout
+ * Description: Reusable fetch wrapper with timeout JavaScript utility snippet for frontend projects.
+ * Author: DevSnips Contributors
+ * Usage Example: Open `devsnips/snippets/js-snippets/Fetch Wrapper with Timeout.js` and copy the snippet into your project.
+ */
+
 async function fetchWithTimeout(url,opts={},t=8000){
 const controller=new AbortController();const id=setTimeout(()=>controller.abort(),t);
 try{const res=await fetch(url,{...opts,signal:controller.signal});clearTimeout(id);if(!res.ok)throw new Error(res.statusText);return await res.json();}catch(e){throw e}

--- a/devsnips/snippets/js-snippets/Focus Trap (modal).js
+++ b/devsnips/snippets/js-snippets/Focus Trap (modal).js
@@ -1,3 +1,10 @@
+/**
+ * Snippet Name: Focus Trap (Modal)
+ * Description: Reusable focus trap (modal) JavaScript utility snippet for frontend projects.
+ * Author: DevSnips Contributors
+ * Usage Example: Open `devsnips/snippets/js-snippets/Focus Trap (modal).js` and copy the snippet into your project.
+ */
+
 function trapFocus(container){const focusable='a[href],button,input,textarea,select,[tabindex]:not([tabindex="-1"])';
 const nodes=[...container.querySelectorAll(focusable)];if(!nodes.length) return;
 const first=nodes[0],last=nodes[nodes.length-1];

--- a/devsnips/snippets/js-snippets/LocalStorage JSON Helpers.js
+++ b/devsnips/snippets/js-snippets/LocalStorage JSON Helpers.js
@@ -1,1 +1,8 @@
+/**
+ * Snippet Name: Localstorage Json Helpers
+ * Description: Reusable localstorage json helpers JavaScript utility snippet for frontend projects.
+ * Author: DevSnips Contributors
+ * Usage Example: Open `devsnips/snippets/js-snippets/LocalStorage JSON Helpers.js` and copy the snippet into your project.
+ */
+
 const storage={get(k){try{return JSON.parse(localStorage.getItem(k))}catch{return null}},set(k,v){localStorage.setItem(k,JSON.stringify(v))},remove(k){localStorage.removeItem(k)}}

--- a/devsnips/snippets/js-snippets/Progressive Image (blur-up).html
+++ b/devsnips/snippets/js-snippets/Progressive Image (blur-up).html
@@ -1,3 +1,10 @@
+<!--
+Snippet Name: Progressive Image (Blur Up)
+Description: Reusable progressive image (blur up) snippet for frontend projects.
+Author: DevSnips Contributors
+Usage Example: Open `devsnips/snippets/js-snippets/Progressive Image (blur-up).html` and copy the snippet into your project.
+-->
+
 <img src="low.jpg" data-high="high.jpg" class="progressive" alt="">
 
 

--- a/devsnips/snippets/js-snippets/Responsive Sticky Header with Shadow.html
+++ b/devsnips/snippets/js-snippets/Responsive Sticky Header with Shadow.html
@@ -1,3 +1,10 @@
+<!--
+Snippet Name: Responsive Sticky Header With Shadow
+Description: Reusable responsive sticky header with shadow snippet for frontend projects.
+Author: DevSnips Contributors
+Usage Example: Open `devsnips/snippets/js-snippets/Responsive Sticky Header with Shadow.html` and copy the snippet into your project.
+-->
+
 <header class="sticky-header">My Site</header>
 
 

--- a/devsnips/snippets/js-snippets/clipboard-copy-helper.js
+++ b/devsnips/snippets/js-snippets/clipboard-copy-helper.js
@@ -1,0 +1,26 @@
+/**
+ * Snippet Name: Clipboard Copy Helper
+ * Description: Copies text to clipboard with async API and fallback support.
+ * Author: DevSnips Contributors
+ * Usage Example: await copyToClipboard('hello world');
+ */
+
+const copyToClipboard = async (text) => {
+  if (navigator?.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return true;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand('copy');
+  document.body.removeChild(textarea);
+  return copied;
+};
+
+export default copyToClipboard;

--- a/devsnips/snippets/js-snippets/debounce-utility.js
+++ b/devsnips/snippets/js-snippets/debounce-utility.js
@@ -1,0 +1,17 @@
+/**
+ * Snippet Name: Debounce Utility
+ * Description: Delays rapid function calls until user input settles.
+ * Author: DevSnips Contributors
+ * Usage Example: const onInput = debounce(fetchResults, 250);
+ */
+
+const debounce = (callback, wait = 200) => {
+  let timeoutId;
+
+  return (...args) => {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => callback(...args), wait);
+  };
+};
+
+export default debounce;

--- a/devsnips/snippets/js-snippets/form-validator.js
+++ b/devsnips/snippets/js-snippets/form-validator.js
@@ -1,0 +1,25 @@
+/**
+ * Snippet Name: Form Validator
+ * Description: Validates required, email, and minimum length rules.
+ * Author: DevSnips Contributors
+ * Usage Example: const errors = validateForm(values, rules);
+ */
+
+const validators = {
+  required: (value) => value.trim().length > 0,
+  email: (value) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value),
+  minLength: (value, length) => value.trim().length >= Number(length)
+};
+
+const validateForm = (values, rules) => Object.entries(rules).reduce((errors, [field, fieldRules]) => {
+  const value = String(values[field] ?? '');
+  const failedRule = fieldRules.find(({ rule, param }) => !validators[rule](value, param));
+
+  if (failedRule) {
+    errors[field] = failedRule.message;
+  }
+
+  return errors;
+}, {});
+
+export default validateForm;

--- a/devsnips/snippets/js-snippets/lazy-image-loader.js
+++ b/devsnips/snippets/js-snippets/lazy-image-loader.js
@@ -1,0 +1,25 @@
+/**
+ * Snippet Name: Lazy Image Loader
+ * Description: Loads images on demand using IntersectionObserver.
+ * Author: DevSnips Contributors
+ * Usage Example: lazyLoadImages(document.querySelectorAll('img[data-src]'));
+ */
+
+const lazyLoadImages = (images) => {
+  const observer = new IntersectionObserver((entries, obs) => {
+    entries.forEach((entry) => {
+      if (!entry.isIntersecting) {
+        return;
+      }
+
+      const image = entry.target;
+      image.src = image.dataset.src;
+      image.removeAttribute('data-src');
+      obs.unobserve(image);
+    });
+  }, { rootMargin: '200px 0px' });
+
+  images.forEach((image) => observer.observe(image));
+};
+
+export default lazyLoadImages;

--- a/devsnips/snippets/js-snippets/local-storage-wrapper.js
+++ b/devsnips/snippets/js-snippets/local-storage-wrapper.js
@@ -1,0 +1,25 @@
+/**
+ * Snippet Name: Local Storage Wrapper
+ * Description: Safe JSON-based localStorage helper with get/set/remove methods.
+ * Author: DevSnips Contributors
+ * Usage Example: storage.set('theme', { mode: 'dark' });
+ */
+
+const storage = {
+  get(key, fallback = null) {
+    try {
+      const value = localStorage.getItem(key);
+      return value ? JSON.parse(value) : fallback;
+    } catch {
+      return fallback;
+    }
+  },
+  set(key, value) {
+    localStorage.setItem(key, JSON.stringify(value));
+  },
+  remove(key) {
+    localStorage.removeItem(key);
+  }
+};
+
+export default storage;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,22 @@
+export default [
+  {
+    files: ["devsnips/snippets/js-snippets/**/*.js"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        window: "readonly",
+        document: "readonly",
+        navigator: "readonly",
+        localStorage: "readonly",
+        IntersectionObserver: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly"
+      }
+    },
+    rules: {
+      "no-var": "error",
+      "prefer-const": "error"
+    }
+  }
+];

--- a/snippets-index.json
+++ b/snippets-index.json
@@ -1,0 +1,4536 @@
+[
+  {
+    "name": "3D Button Effect",
+    "path": "devsnips/snippets/html-snippets/3d-button-effect.html",
+    "category": "html",
+    "tags": [
+      "3d",
+      "button",
+      "effect",
+      "html"
+    ],
+    "description": "Reusable 3d button effect snippet."
+  },
+  {
+    "name": "3D Text Effect",
+    "path": "devsnips/snippets/html-snippets/3d-text-effect.html",
+    "category": "html",
+    "tags": [
+      "3d",
+      "effect",
+      "html",
+      "text"
+    ],
+    "description": "Reusable 3d text effect snippet."
+  },
+  {
+    "name": "404 Not Found Page",
+    "path": "devsnips/snippets/html-snippets/404-not-found-page.html",
+    "category": "html",
+    "tags": [
+      "404",
+      "found",
+      "html",
+      "not",
+      "page"
+    ],
+    "description": "Reusable 404 not found page snippet."
+  },
+  {
+    "name": "Abbr Element",
+    "path": "devsnips/snippets/html-snippets/abbr-element.html",
+    "category": "html",
+    "tags": [
+      "abbr",
+      "element",
+      "html"
+    ],
+    "description": "Reusable abbr element snippet."
+  },
+  {
+    "name": "Accessible Image",
+    "path": "devsnips/snippets/html-snippets/accessible-image.html",
+    "category": "html",
+    "tags": [
+      "accessible",
+      "html",
+      "image"
+    ],
+    "description": "Reusable accessible image snippet."
+  },
+  {
+    "name": "Accordion Faq Layout",
+    "path": "devsnips/snippets/html-snippets/accordion-faq-layout.html",
+    "category": "html",
+    "tags": [
+      "accordion",
+      "faq",
+      "html",
+      "layout"
+    ],
+    "description": "Reusable accordion faq layout snippet."
+  },
+  {
+    "name": "Action Buttons",
+    "path": "devsnips/snippets/html-snippets/action-buttons.html",
+    "category": "html",
+    "tags": [
+      "action",
+      "buttons",
+      "html"
+    ],
+    "description": "Reusable action buttons snippet."
+  },
+  {
+    "name": "Address Tag",
+    "path": "devsnips/snippets/html-snippets/address-tag.html",
+    "category": "html",
+    "tags": [
+      "address",
+      "html",
+      "tag"
+    ],
+    "description": "Reusable address tag snippet."
+  },
+  {
+    "name": "Alert Messages",
+    "path": "devsnips/snippets/html-snippets/alert-messages.html",
+    "category": "html",
+    "tags": [
+      "alert",
+      "html",
+      "messages"
+    ],
+    "description": "Reusable alert messages snippet."
+  },
+  {
+    "name": "Animated Gradient Background",
+    "path": "devsnips/snippets/html-snippets/animated-gradient-background.html",
+    "category": "html",
+    "tags": [
+      "animated",
+      "background",
+      "gradient",
+      "html"
+    ],
+    "description": "Reusable animated gradient background snippet."
+  },
+  {
+    "name": "Audio Embed",
+    "path": "devsnips/snippets/html-snippets/audio-embed.html",
+    "category": "html",
+    "tags": [
+      "audio",
+      "embed",
+      "html"
+    ],
+    "description": "Reusable audio embed snippet."
+  },
+  {
+    "name": "Back To Top Button",
+    "path": "devsnips/snippets/html-snippets/back-to-top-button.html",
+    "category": "html",
+    "tags": [
+      "back",
+      "button",
+      "html",
+      "to",
+      "top"
+    ],
+    "description": "Reusable back to top button snippet."
+  },
+  {
+    "name": "Basic Navbar",
+    "path": "devsnips/snippets/html-snippets/basic-navbar.html",
+    "category": "html",
+    "tags": [
+      "basic",
+      "html",
+      "navbar"
+    ],
+    "description": "Reusable basic navbar snippet."
+  },
+  {
+    "name": "Bdi Element",
+    "path": "devsnips/snippets/html-snippets/bdi-element.html",
+    "category": "html",
+    "tags": [
+      "bdi",
+      "element",
+      "html"
+    ],
+    "description": "Reusable bdi element snippet."
+  },
+  {
+    "name": "Blockquote Citation",
+    "path": "devsnips/snippets/html-snippets/blockquote-citation.html",
+    "category": "html",
+    "tags": [
+      "blockquote",
+      "citation",
+      "html"
+    ],
+    "description": "Reusable blockquote citation snippet."
+  },
+  {
+    "name": "Blockquote With Cite",
+    "path": "devsnips/snippets/html-snippets/blockquote-with-cite.html",
+    "category": "html",
+    "tags": [
+      "blockquote",
+      "cite",
+      "html",
+      "with"
+    ],
+    "description": "Reusable blockquote with cite snippet."
+  },
+  {
+    "name": "Blog Post Card",
+    "path": "devsnips/snippets/html-snippets/blog-post-card.html",
+    "category": "html",
+    "tags": [
+      "blog",
+      "card",
+      "html",
+      "post"
+    ],
+    "description": "Reusable blog post card snippet."
+  },
+  {
+    "name": "Bottom Navigation",
+    "path": "devsnips/snippets/html-snippets/bottom-navigation.html",
+    "category": "html",
+    "tags": [
+      "bottom",
+      "html",
+      "navigation"
+    ],
+    "description": "Reusable bottom navigation snippet."
+  },
+  {
+    "name": "Bouncing Loader",
+    "path": "devsnips/snippets/html-snippets/bouncing-loader.html",
+    "category": "html",
+    "tags": [
+      "bouncing",
+      "html",
+      "loader"
+    ],
+    "description": "Reusable bouncing loader snippet."
+  },
+  {
+    "name": "Breadcrumbs Navigation",
+    "path": "devsnips/snippets/html-snippets/breadcrumbs-navigation.html",
+    "category": "html",
+    "tags": [
+      "breadcrumbs",
+      "html",
+      "navigation"
+    ],
+    "description": "Reusable breadcrumbs navigation snippet."
+  },
+  {
+    "name": "Calendar Widget",
+    "path": "devsnips/snippets/html-snippets/calendar-widget.html",
+    "category": "html",
+    "tags": [
+      "calendar",
+      "html",
+      "widget"
+    ],
+    "description": "Reusable calendar widget snippet."
+  },
+  {
+    "name": "Canvas Element",
+    "path": "devsnips/snippets/html-snippets/canvas-element.html",
+    "category": "html",
+    "tags": [
+      "canvas",
+      "element",
+      "html"
+    ],
+    "description": "Reusable canvas element snippet."
+  },
+  {
+    "name": "Carousel",
+    "path": "devsnips/snippets/html-snippets/carousel.html",
+    "category": "html",
+    "tags": [
+      "carousel",
+      "html"
+    ],
+    "description": "Reusable carousel snippet."
+  },
+  {
+    "name": "Centered Website",
+    "path": "devsnips/snippets/html-snippets/centered-website.html",
+    "category": "html",
+    "tags": [
+      "centered",
+      "html",
+      "website"
+    ],
+    "description": "Reusable centered website snippet."
+  },
+  {
+    "name": "Checkbox Group",
+    "path": "devsnips/snippets/html-snippets/checkbox-group.html",
+    "category": "html",
+    "tags": [
+      "checkbox",
+      "group",
+      "html"
+    ],
+    "description": "Reusable checkbox group snippet."
+  },
+  {
+    "name": "Circular Menu",
+    "path": "devsnips/snippets/html-snippets/circular-menu.html",
+    "category": "html",
+    "tags": [
+      "circular",
+      "html",
+      "menu"
+    ],
+    "description": "Reusable circular menu snippet."
+  },
+  {
+    "name": "Circular Progress Bar",
+    "path": "devsnips/snippets/html-snippets/circular-progress-bar.html",
+    "category": "html",
+    "tags": [
+      "bar",
+      "circular",
+      "html",
+      "progress"
+    ],
+    "description": "Reusable circular progress bar snippet."
+  },
+  {
+    "name": "Code Block",
+    "path": "devsnips/snippets/html-snippets/code-block.html",
+    "category": "html",
+    "tags": [
+      "block",
+      "code",
+      "html"
+    ],
+    "description": "Reusable code block snippet."
+  },
+  {
+    "name": "Collapsible Accordion",
+    "path": "devsnips/snippets/html-snippets/collapsible-accordion.html",
+    "category": "html",
+    "tags": [
+      "accordion",
+      "collapsible",
+      "html"
+    ],
+    "description": "Reusable collapsible accordion snippet."
+  },
+  {
+    "name": "Collapsible",
+    "path": "devsnips/snippets/html-snippets/collapsible.html",
+    "category": "html",
+    "tags": [
+      "collapsible",
+      "html"
+    ],
+    "description": "Reusable collapsible snippet."
+  },
+  {
+    "name": "Color Picker",
+    "path": "devsnips/snippets/html-snippets/color-picker.html",
+    "category": "html",
+    "tags": [
+      "color",
+      "html",
+      "picker"
+    ],
+    "description": "Reusable color picker snippet."
+  },
+  {
+    "name": "Coming Soon Page",
+    "path": "devsnips/snippets/html-snippets/coming-soon-page.html",
+    "category": "html",
+    "tags": [
+      "coming",
+      "html",
+      "page",
+      "soon"
+    ],
+    "description": "Reusable coming soon page snippet."
+  },
+  {
+    "name": "Contact Chip",
+    "path": "devsnips/snippets/html-snippets/contact-chip.html",
+    "category": "html",
+    "tags": [
+      "chip",
+      "contact",
+      "html"
+    ],
+    "description": "Reusable contact chip snippet."
+  },
+  {
+    "name": "Contact Form Basic",
+    "path": "devsnips/snippets/html-snippets/contact-form-basic.html",
+    "category": "html",
+    "tags": [
+      "basic",
+      "contact",
+      "form",
+      "html"
+    ],
+    "description": "Reusable contact form basic snippet."
+  },
+  {
+    "name": "Contact Form",
+    "path": "devsnips/snippets/html-snippets/contact-form.html",
+    "category": "html",
+    "tags": [
+      "contact",
+      "form",
+      "html"
+    ],
+    "description": "Reusable contact form snippet."
+  },
+  {
+    "name": "Content Editable",
+    "path": "devsnips/snippets/html-snippets/content-editable.html",
+    "category": "html",
+    "tags": [
+      "content",
+      "editable",
+      "html"
+    ],
+    "description": "Reusable content editable snippet."
+  },
+  {
+    "name": "Cookie Consent Banner",
+    "path": "devsnips/snippets/html-snippets/cookie-consent-banner.html",
+    "category": "html",
+    "tags": [
+      "banner",
+      "consent",
+      "cookie",
+      "html"
+    ],
+    "description": "Reusable cookie consent banner snippet."
+  },
+  {
+    "name": "Corner Ribbon",
+    "path": "devsnips/snippets/html-snippets/corner-ribbon.html",
+    "category": "html",
+    "tags": [
+      "corner",
+      "html",
+      "ribbon"
+    ],
+    "description": "Reusable corner ribbon snippet."
+  },
+  {
+    "name": "Countdown Timer",
+    "path": "devsnips/snippets/html-snippets/countdown-timer.html",
+    "category": "html",
+    "tags": [
+      "countdown",
+      "html",
+      "timer"
+    ],
+    "description": "Reusable countdown timer snippet."
+  },
+  {
+    "name": "Creative Image Hover",
+    "path": "devsnips/snippets/html-snippets/creative-image-hover.html",
+    "category": "html",
+    "tags": [
+      "creative",
+      "hover",
+      "html",
+      "image"
+    ],
+    "description": "Reusable creative image hover snippet."
+  },
+  {
+    "name": "Custom Scrollbar",
+    "path": "devsnips/snippets/html-snippets/custom-scrollbar.html",
+    "category": "html",
+    "tags": [
+      "custom",
+      "html",
+      "scrollbar"
+    ],
+    "description": "Reusable custom scrollbar snippet."
+  },
+  {
+    "name": "Cutout Text Effect",
+    "path": "devsnips/snippets/html-snippets/cutout-text-effect.html",
+    "category": "html",
+    "tags": [
+      "cutout",
+      "effect",
+      "html",
+      "text"
+    ],
+    "description": "Reusable cutout text effect snippet."
+  },
+  {
+    "name": "Datalist Autocomplete",
+    "path": "devsnips/snippets/html-snippets/datalist-autocomplete.html",
+    "category": "html",
+    "tags": [
+      "autocomplete",
+      "datalist",
+      "html"
+    ],
+    "description": "Reusable datalist autocomplete snippet."
+  },
+  {
+    "name": "Definition List",
+    "path": "devsnips/snippets/html-snippets/definition-list.html",
+    "category": "html",
+    "tags": [
+      "definition",
+      "html",
+      "list"
+    ],
+    "description": "Reusable definition list snippet."
+  },
+  {
+    "name": "Details Summary",
+    "path": "devsnips/snippets/html-snippets/details-summary.html",
+    "category": "html",
+    "tags": [
+      "details",
+      "html",
+      "summary"
+    ],
+    "description": "Reusable details summary snippet."
+  },
+  {
+    "name": "Device Mockups",
+    "path": "devsnips/snippets/html-snippets/device-mockups.html",
+    "category": "html",
+    "tags": [
+      "device",
+      "html",
+      "mockups"
+    ],
+    "description": "Reusable device mockups snippet."
+  },
+  {
+    "name": "Diagonal Background",
+    "path": "devsnips/snippets/html-snippets/diagonal-background.html",
+    "category": "html",
+    "tags": [
+      "background",
+      "diagonal",
+      "html"
+    ],
+    "description": "Reusable diagonal background snippet."
+  },
+  {
+    "name": "Dialog Element",
+    "path": "devsnips/snippets/html-snippets/dialog-element.html",
+    "category": "html",
+    "tags": [
+      "dialog",
+      "element",
+      "html"
+    ],
+    "description": "Reusable dialog element snippet."
+  },
+  {
+    "name": "Disabled Input",
+    "path": "devsnips/snippets/html-snippets/disabled-input.html",
+    "category": "html",
+    "tags": [
+      "disabled",
+      "html",
+      "input"
+    ],
+    "description": "Reusable disabled input snippet."
+  },
+  {
+    "name": "Download Button",
+    "path": "devsnips/snippets/html-snippets/download-button.html",
+    "category": "html",
+    "tags": [
+      "button",
+      "download",
+      "html"
+    ],
+    "description": "Reusable download button snippet."
+  },
+  {
+    "name": "Draggable Element",
+    "path": "devsnips/snippets/html-snippets/draggable-element.html",
+    "category": "html",
+    "tags": [
+      "draggable",
+      "element",
+      "html"
+    ],
+    "description": "Reusable draggable element snippet."
+  },
+  {
+    "name": "Dropdown Menu",
+    "path": "devsnips/snippets/html-snippets/dropdown-menu.html",
+    "category": "html",
+    "tags": [
+      "dropdown",
+      "html",
+      "menu"
+    ],
+    "description": "Reusable dropdown menu snippet."
+  },
+  {
+    "name": "Fade In Effect",
+    "path": "devsnips/snippets/html-snippets/fade-in-effect.html",
+    "category": "html",
+    "tags": [
+      "effect",
+      "fade",
+      "html",
+      "in"
+    ],
+    "description": "Reusable fade in effect snippet."
+  },
+  {
+    "name": "Favicon Link",
+    "path": "devsnips/snippets/html-snippets/favicon-link.html",
+    "category": "html",
+    "tags": [
+      "favicon",
+      "html",
+      "link"
+    ],
+    "description": "Reusable favicon link snippet."
+  },
+  {
+    "name": "Fieldset Legend",
+    "path": "devsnips/snippets/html-snippets/fieldset-legend.html",
+    "category": "html",
+    "tags": [
+      "fieldset",
+      "html",
+      "legend"
+    ],
+    "description": "Reusable fieldset legend snippet."
+  },
+  {
+    "name": "Figure Figcaption",
+    "path": "devsnips/snippets/html-snippets/figure-figcaption.html",
+    "category": "html",
+    "tags": [
+      "figcaption",
+      "figure",
+      "html"
+    ],
+    "description": "Reusable figure figcaption snippet."
+  },
+  {
+    "name": "Figure With Figcaption",
+    "path": "devsnips/snippets/html-snippets/figure-with-figcaption.html",
+    "category": "html",
+    "tags": [
+      "figcaption",
+      "figure",
+      "html",
+      "with"
+    ],
+    "description": "Reusable figure with figcaption snippet."
+  },
+  {
+    "name": "File Upload Input",
+    "path": "devsnips/snippets/html-snippets/file-upload-input.html",
+    "category": "html",
+    "tags": [
+      "file",
+      "html",
+      "input",
+      "upload"
+    ],
+    "description": "Reusable file upload input snippet."
+  },
+  {
+    "name": "Filter List",
+    "path": "devsnips/snippets/html-snippets/filter-list.html",
+    "category": "html",
+    "tags": [
+      "filter",
+      "html",
+      "list"
+    ],
+    "description": "Reusable filter list snippet."
+  },
+  {
+    "name": "Fixed Header On Scroll",
+    "path": "devsnips/snippets/html-snippets/fixed-header-on-scroll.html",
+    "category": "html",
+    "tags": [
+      "fixed",
+      "header",
+      "html",
+      "on",
+      "scroll"
+    ],
+    "description": "Reusable fixed header on scroll snippet."
+  },
+  {
+    "name": "Fixed Sidebar",
+    "path": "devsnips/snippets/html-snippets/fixed-sidebar.html",
+    "category": "html",
+    "tags": [
+      "fixed",
+      "html",
+      "sidebar"
+    ],
+    "description": "Reusable fixed sidebar snippet."
+  },
+  {
+    "name": "Flipping Card",
+    "path": "devsnips/snippets/html-snippets/flipping-card.html",
+    "category": "html",
+    "tags": [
+      "card",
+      "flipping",
+      "html"
+    ],
+    "description": "Reusable flipping card snippet."
+  },
+  {
+    "name": "Fluid Grid",
+    "path": "devsnips/snippets/html-snippets/fluid-grid.html",
+    "category": "html",
+    "tags": [
+      "fluid",
+      "grid",
+      "html"
+    ],
+    "description": "Reusable fluid grid snippet."
+  },
+  {
+    "name": "Footer",
+    "path": "devsnips/snippets/html-snippets/footer.html",
+    "category": "html",
+    "tags": [
+      "footer",
+      "html"
+    ],
+    "description": "Reusable footer snippet."
+  },
+  {
+    "name": "Four Column Layout",
+    "path": "devsnips/snippets/html-snippets/four-column-layout.html",
+    "category": "html",
+    "tags": [
+      "column",
+      "four",
+      "html",
+      "layout"
+    ],
+    "description": "Reusable four column layout snippet."
+  },
+  {
+    "name": "Full Page Tabs",
+    "path": "devsnips/snippets/html-snippets/full-page-tabs.html",
+    "category": "html",
+    "tags": [
+      "full",
+      "html",
+      "page",
+      "tabs"
+    ],
+    "description": "Reusable full page tabs snippet."
+  },
+  {
+    "name": "Full Screen Search",
+    "path": "devsnips/snippets/html-snippets/full-screen-search.html",
+    "category": "html",
+    "tags": [
+      "full",
+      "html",
+      "screen",
+      "search"
+    ],
+    "description": "Reusable full screen search snippet."
+  },
+  {
+    "name": "Full Width Image",
+    "path": "devsnips/snippets/html-snippets/full-width-image.html",
+    "category": "html",
+    "tags": [
+      "full",
+      "html",
+      "image",
+      "width"
+    ],
+    "description": "Reusable full width image snippet."
+  },
+  {
+    "name": "Gelatine Animation",
+    "path": "devsnips/snippets/html-snippets/gelatine-animation.html",
+    "category": "html",
+    "tags": [
+      "animation",
+      "gelatine",
+      "html"
+    ],
+    "description": "Reusable gelatine animation snippet."
+  },
+  {
+    "name": "Glowing Icon",
+    "path": "devsnips/snippets/html-snippets/glowing-icon.html",
+    "category": "html",
+    "tags": [
+      "glowing",
+      "html",
+      "icon"
+    ],
+    "description": "Reusable glowing icon snippet."
+  },
+  {
+    "name": "Gradient Text",
+    "path": "devsnips/snippets/html-snippets/gradient-text.html",
+    "category": "html",
+    "tags": [
+      "gradient",
+      "html",
+      "text"
+    ],
+    "description": "Reusable gradient text snippet."
+  },
+  {
+    "name": "Hamburger Menu",
+    "path": "devsnips/snippets/html-snippets/hamburger-menu.html",
+    "category": "html",
+    "tags": [
+      "hamburger",
+      "html",
+      "menu"
+    ],
+    "description": "Reusable hamburger menu snippet."
+  },
+  {
+    "name": "Header",
+    "path": "devsnips/snippets/html-snippets/header.html",
+    "category": "html",
+    "tags": [
+      "header",
+      "html"
+    ],
+    "description": "Reusable header snippet."
+  },
+  {
+    "name": "Heartbeat Animation",
+    "path": "devsnips/snippets/html-snippets/heartbeat-animation.html",
+    "category": "html",
+    "tags": [
+      "animation",
+      "heartbeat",
+      "html"
+    ],
+    "description": "Reusable heartbeat animation snippet."
+  },
+  {
+    "name": "Hidden Attribute",
+    "path": "devsnips/snippets/html-snippets/hidden-attribute.html",
+    "category": "html",
+    "tags": [
+      "attribute",
+      "hidden",
+      "html"
+    ],
+    "description": "Reusable hidden attribute snippet."
+  },
+  {
+    "name": "Holy Grail Layout",
+    "path": "devsnips/snippets/html-snippets/holy-grail-layout.html",
+    "category": "html",
+    "tags": [
+      "grail",
+      "holy",
+      "html",
+      "layout"
+    ],
+    "description": "Reusable holy grail layout snippet."
+  },
+  {
+    "name": "Horizontal Rule",
+    "path": "devsnips/snippets/html-snippets/horizontal-rule.html",
+    "category": "html",
+    "tags": [
+      "horizontal",
+      "html",
+      "rule"
+    ],
+    "description": "Reusable horizontal rule snippet."
+  },
+  {
+    "name": "Html5 Audio Player",
+    "path": "devsnips/snippets/html-snippets/html5-audio-player.html",
+    "category": "html",
+    "tags": [
+      "audio",
+      "html",
+      "html5",
+      "player"
+    ],
+    "description": "Reusable html5 audio player snippet."
+  },
+  {
+    "name": "Html5 Boilerplate",
+    "path": "devsnips/snippets/html-snippets/html5-boilerplate.html",
+    "category": "html",
+    "tags": [
+      "boilerplate",
+      "html",
+      "html5"
+    ],
+    "description": "Reusable html5 boilerplate snippet."
+  },
+  {
+    "name": "Html5 Video Player",
+    "path": "devsnips/snippets/html-snippets/html5-video-player.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "html5",
+      "player",
+      "video"
+    ],
+    "description": "Reusable html5 video player snippet."
+  },
+  {
+    "name": "Iframe Embed",
+    "path": "devsnips/snippets/html-snippets/iframe-embed.html",
+    "category": "html",
+    "tags": [
+      "embed",
+      "html",
+      "iframe"
+    ],
+    "description": "Reusable iframe embed snippet."
+  },
+  {
+    "name": "Image Map",
+    "path": "devsnips/snippets/html-snippets/image-map.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "image",
+      "map"
+    ],
+    "description": "Reusable image map snippet."
+  },
+  {
+    "name": "Image Overlay Effect",
+    "path": "devsnips/snippets/html-snippets/image-overlay-effect.html",
+    "category": "html",
+    "tags": [
+      "effect",
+      "html",
+      "image",
+      "overlay"
+    ],
+    "description": "Reusable image overlay effect snippet."
+  },
+  {
+    "name": "Image Zoom On Hover",
+    "path": "devsnips/snippets/html-snippets/image-zoom-on-hover.html",
+    "category": "html",
+    "tags": [
+      "hover",
+      "html",
+      "image",
+      "on",
+      "zoom"
+    ],
+    "description": "Reusable image zoom on hover snippet."
+  },
+  {
+    "name": "Input Pattern Validation",
+    "path": "devsnips/snippets/html-snippets/input-pattern-validation.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "input",
+      "pattern",
+      "validation"
+    ],
+    "description": "Reusable input pattern validation snippet."
+  },
+  {
+    "name": "Input With Min Max",
+    "path": "devsnips/snippets/html-snippets/input-with-min-max.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "input",
+      "max",
+      "min",
+      "with"
+    ],
+    "description": "Reusable input with min max snippet."
+  },
+  {
+    "name": "Jumbotron",
+    "path": "devsnips/snippets/html-snippets/jumbotron.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "jumbotron"
+    ],
+    "description": "Reusable jumbotron snippet."
+  },
+  {
+    "name": "Keyboard Input",
+    "path": "devsnips/snippets/html-snippets/keyboard-input.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "input",
+      "keyboard"
+    ],
+    "description": "Reusable keyboard input snippet."
+  },
+  {
+    "name": "List Group",
+    "path": "devsnips/snippets/html-snippets/list-group.html",
+    "category": "html",
+    "tags": [
+      "group",
+      "html",
+      "list"
+    ],
+    "description": "Reusable list group snippet."
+  },
+  {
+    "name": "Loader",
+    "path": "devsnips/snippets/html-snippets/loader.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "loader"
+    ],
+    "description": "Reusable loader snippet."
+  },
+  {
+    "name": "Login Form",
+    "path": "devsnips/snippets/html-snippets/login-form.html",
+    "category": "html",
+    "tags": [
+      "form",
+      "html",
+      "login"
+    ],
+    "description": "Reusable login form snippet."
+  },
+  {
+    "name": "Main Element",
+    "path": "devsnips/snippets/html-snippets/main-element.html",
+    "category": "html",
+    "tags": [
+      "element",
+      "html",
+      "main"
+    ],
+    "description": "Reusable main element snippet."
+  },
+  {
+    "name": "Mark Text",
+    "path": "devsnips/snippets/html-snippets/mark-text.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "mark",
+      "text"
+    ],
+    "description": "Reusable mark text snippet."
+  },
+  {
+    "name": "Media Object",
+    "path": "devsnips/snippets/html-snippets/media-object.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "media",
+      "object"
+    ],
+    "description": "Reusable media object snippet."
+  },
+  {
+    "name": "Mega Menu",
+    "path": "devsnips/snippets/html-snippets/mega-menu.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "mega",
+      "menu"
+    ],
+    "description": "Reusable mega menu snippet."
+  },
+  {
+    "name": "Meter Element",
+    "path": "devsnips/snippets/html-snippets/meter-element.html",
+    "category": "html",
+    "tags": [
+      "element",
+      "html",
+      "meter"
+    ],
+    "description": "Reusable meter element snippet."
+  },
+  {
+    "name": "Mixed Column Layout",
+    "path": "devsnips/snippets/html-snippets/mixed-column-layout.html",
+    "category": "html",
+    "tags": [
+      "column",
+      "html",
+      "layout",
+      "mixed"
+    ],
+    "description": "Reusable mixed column layout snippet."
+  },
+  {
+    "name": "Modal Box",
+    "path": "devsnips/snippets/html-snippets/modal-box.html",
+    "category": "html",
+    "tags": [
+      "box",
+      "html",
+      "modal"
+    ],
+    "description": "Reusable modal box snippet."
+  },
+  {
+    "name": "Modal Dialog",
+    "path": "devsnips/snippets/html-snippets/modal-dialog.html",
+    "category": "html",
+    "tags": [
+      "dialog",
+      "html",
+      "modal"
+    ],
+    "description": "Reusable modal dialog snippet."
+  },
+  {
+    "name": "Multi Select Dropdown",
+    "path": "devsnips/snippets/html-snippets/multi-select-dropdown.html",
+    "category": "html",
+    "tags": [
+      "dropdown",
+      "html",
+      "multi",
+      "select"
+    ],
+    "description": "Reusable multi select dropdown snippet."
+  },
+  {
+    "name": "Neon Text",
+    "path": "devsnips/snippets/html-snippets/neon-text.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "neon",
+      "text"
+    ],
+    "description": "Reusable neon text snippet."
+  },
+  {
+    "name": "Newsletter Signup Form",
+    "path": "devsnips/snippets/html-snippets/newsletter-signup-form.html",
+    "category": "html",
+    "tags": [
+      "form",
+      "html",
+      "newsletter",
+      "signup"
+    ],
+    "description": "Reusable newsletter signup form snippet."
+  },
+  {
+    "name": "Notification Badge",
+    "path": "devsnips/snippets/html-snippets/notification-badge.html",
+    "category": "html",
+    "tags": [
+      "badge",
+      "html",
+      "notification"
+    ],
+    "description": "Reusable notification badge snippet."
+  },
+  {
+    "name": "One Page Scrolling",
+    "path": "devsnips/snippets/html-snippets/one-page-scrolling.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "one",
+      "page",
+      "scrolling"
+    ],
+    "description": "Reusable one page scrolling snippet."
+  },
+  {
+    "name": "Output Element",
+    "path": "devsnips/snippets/html-snippets/output-element.html",
+    "category": "html",
+    "tags": [
+      "element",
+      "html",
+      "output"
+    ],
+    "description": "Reusable output element snippet."
+  },
+  {
+    "name": "Pagination Component",
+    "path": "devsnips/snippets/html-snippets/pagination-component.html",
+    "category": "html",
+    "tags": [
+      "component",
+      "html",
+      "pagination"
+    ],
+    "description": "Reusable pagination component snippet."
+  },
+  {
+    "name": "Parallax Scrolling Effect",
+    "path": "devsnips/snippets/html-snippets/parallax-scrolling-effect.html",
+    "category": "html",
+    "tags": [
+      "effect",
+      "html",
+      "parallax",
+      "scrolling"
+    ],
+    "description": "Reusable parallax scrolling effect snippet."
+  },
+  {
+    "name": "Perfectly Centered Div",
+    "path": "devsnips/snippets/html-snippets/perfectly-centered-div.html",
+    "category": "html",
+    "tags": [
+      "centered",
+      "div",
+      "html",
+      "perfectly"
+    ],
+    "description": "Reusable perfectly centered div snippet."
+  },
+  {
+    "name": "Picture Element",
+    "path": "devsnips/snippets/html-snippets/picture-element.html",
+    "category": "html",
+    "tags": [
+      "element",
+      "html",
+      "picture"
+    ],
+    "description": "Reusable picture element snippet."
+  },
+  {
+    "name": "Pills",
+    "path": "devsnips/snippets/html-snippets/pills.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "pills"
+    ],
+    "description": "Reusable pills snippet."
+  },
+  {
+    "name": "Pop Up Image",
+    "path": "devsnips/snippets/html-snippets/pop-up-image.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "image",
+      "pop",
+      "up"
+    ],
+    "description": "Reusable pop up image snippet."
+  },
+  {
+    "name": "Popup Chat Window",
+    "path": "devsnips/snippets/html-snippets/popup-chat-window.html",
+    "category": "html",
+    "tags": [
+      "chat",
+      "html",
+      "popup",
+      "window"
+    ],
+    "description": "Reusable popup chat window snippet."
+  },
+  {
+    "name": "Portfolio Gallery",
+    "path": "devsnips/snippets/html-snippets/portfolio-gallery.html",
+    "category": "html",
+    "tags": [
+      "gallery",
+      "html",
+      "portfolio"
+    ],
+    "description": "Reusable portfolio gallery snippet."
+  },
+  {
+    "name": "Pricing Card",
+    "path": "devsnips/snippets/html-snippets/pricing-card.html",
+    "category": "html",
+    "tags": [
+      "card",
+      "html",
+      "pricing"
+    ],
+    "description": "Reusable pricing card snippet."
+  },
+  {
+    "name": "Pricing Table",
+    "path": "devsnips/snippets/html-snippets/pricing-table.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "pricing",
+      "table"
+    ],
+    "description": "Reusable pricing table snippet."
+  },
+  {
+    "name": "Product Card",
+    "path": "devsnips/snippets/html-snippets/product-card.html",
+    "category": "html",
+    "tags": [
+      "card",
+      "html",
+      "product"
+    ],
+    "description": "Reusable product card snippet."
+  },
+  {
+    "name": "Profile Card",
+    "path": "devsnips/snippets/html-snippets/profile-card.html",
+    "category": "html",
+    "tags": [
+      "card",
+      "html",
+      "profile"
+    ],
+    "description": "Reusable profile card snippet."
+  },
+  {
+    "name": "Progress Bar",
+    "path": "devsnips/snippets/html-snippets/progress-bar.html",
+    "category": "html",
+    "tags": [
+      "bar",
+      "html",
+      "progress"
+    ],
+    "description": "Reusable progress bar snippet."
+  },
+  {
+    "name": "Progress Steps",
+    "path": "devsnips/snippets/html-snippets/progress-steps.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "progress",
+      "steps"
+    ],
+    "description": "Reusable progress steps snippet."
+  },
+  {
+    "name": "Pulsing Button",
+    "path": "devsnips/snippets/html-snippets/pulsing-button.html",
+    "category": "html",
+    "tags": [
+      "button",
+      "html",
+      "pulsing"
+    ],
+    "description": "Reusable pulsing button snippet."
+  },
+  {
+    "name": "Radio Button Group",
+    "path": "devsnips/snippets/html-snippets/radio-button-group.html",
+    "category": "html",
+    "tags": [
+      "button",
+      "group",
+      "html",
+      "radio"
+    ],
+    "description": "Reusable radio button group snippet."
+  },
+  {
+    "name": "Range Input",
+    "path": "devsnips/snippets/html-snippets/range-input.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "input",
+      "range"
+    ],
+    "description": "Reusable range input snippet."
+  },
+  {
+    "name": "Range Slider",
+    "path": "devsnips/snippets/html-snippets/range-slider.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "range",
+      "slider"
+    ],
+    "description": "Reusable range slider snippet."
+  },
+  {
+    "name": "Readonly Input",
+    "path": "devsnips/snippets/html-snippets/readonly-input.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "input",
+      "readonly"
+    ],
+    "description": "Reusable readonly input snippet."
+  },
+  {
+    "name": "Registration Form",
+    "path": "devsnips/snippets/html-snippets/registration-form.html",
+    "category": "html",
+    "tags": [
+      "form",
+      "html",
+      "registration"
+    ],
+    "description": "Reusable registration form snippet."
+  },
+  {
+    "name": "Responsive Form",
+    "path": "devsnips/snippets/html-snippets/responsive-form.html",
+    "category": "html",
+    "tags": [
+      "form",
+      "html",
+      "responsive"
+    ],
+    "description": "Reusable responsive form snippet."
+  },
+  {
+    "name": "Responsive Image Gallery",
+    "path": "devsnips/snippets/html-snippets/responsive-image-gallery.html",
+    "category": "html",
+    "tags": [
+      "gallery",
+      "html",
+      "image",
+      "responsive"
+    ],
+    "description": "Reusable responsive image gallery snippet."
+  },
+  {
+    "name": "Responsive Picture",
+    "path": "devsnips/snippets/html-snippets/responsive-picture.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "picture",
+      "responsive"
+    ],
+    "description": "Reusable responsive picture snippet."
+  },
+  {
+    "name": "Responsive Pricing Grid",
+    "path": "devsnips/snippets/html-snippets/responsive-pricing-grid.html",
+    "category": "html",
+    "tags": [
+      "grid",
+      "html",
+      "pricing",
+      "responsive"
+    ],
+    "description": "Reusable responsive pricing grid snippet."
+  },
+  {
+    "name": "Rubber Band Animation",
+    "path": "devsnips/snippets/html-snippets/rubber-band-animation.html",
+    "category": "html",
+    "tags": [
+      "animation",
+      "band",
+      "html",
+      "rubber"
+    ],
+    "description": "Reusable rubber band animation snippet."
+  },
+  {
+    "name": "Search Input",
+    "path": "devsnips/snippets/html-snippets/search-input.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "input",
+      "search"
+    ],
+    "description": "Reusable search input snippet."
+  },
+  {
+    "name": "Select Dropdown",
+    "path": "devsnips/snippets/html-snippets/select-dropdown.html",
+    "category": "html",
+    "tags": [
+      "dropdown",
+      "html",
+      "select"
+    ],
+    "description": "Reusable select dropdown snippet."
+  },
+  {
+    "name": "Select With Optgroup",
+    "path": "devsnips/snippets/html-snippets/select-with-optgroup.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "optgroup",
+      "select",
+      "with"
+    ],
+    "description": "Reusable select with optgroup snippet."
+  },
+  {
+    "name": "Semantic Layout",
+    "path": "devsnips/snippets/html-snippets/semantic-layout.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "layout",
+      "semantic"
+    ],
+    "description": "Reusable semantic layout snippet."
+  },
+  {
+    "name": "Side Navigation",
+    "path": "devsnips/snippets/html-snippets/side-navigation.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "navigation",
+      "side"
+    ],
+    "description": "Reusable side navigation snippet."
+  },
+  {
+    "name": "Simple Footer",
+    "path": "devsnips/snippets/html-snippets/simple-footer.html",
+    "category": "html",
+    "tags": [
+      "footer",
+      "html",
+      "simple"
+    ],
+    "description": "Reusable simple footer snippet."
+  },
+  {
+    "name": "Simple Navigation Menu",
+    "path": "devsnips/snippets/html-snippets/simple-navigation-menu.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "menu",
+      "navigation",
+      "simple"
+    ],
+    "description": "Reusable simple navigation menu snippet."
+  },
+  {
+    "name": "Simple Ordered List",
+    "path": "devsnips/snippets/html-snippets/simple-ordered-list.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "list",
+      "ordered",
+      "simple"
+    ],
+    "description": "Reusable simple ordered list snippet."
+  },
+  {
+    "name": "Simple Table",
+    "path": "devsnips/snippets/html-snippets/simple-table.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "simple",
+      "table"
+    ],
+    "description": "Reusable simple table snippet."
+  },
+  {
+    "name": "Simple Unordered List",
+    "path": "devsnips/snippets/html-snippets/simple-unordered-list.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "list",
+      "simple",
+      "unordered"
+    ],
+    "description": "Reusable simple unordered list snippet."
+  },
+  {
+    "name": "Skeleton Loader",
+    "path": "devsnips/snippets/html-snippets/skeleton-loader.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "loader",
+      "skeleton"
+    ],
+    "description": "Reusable skeleton loader snippet."
+  },
+  {
+    "name": "Skewed Button",
+    "path": "devsnips/snippets/html-snippets/skewed-button.html",
+    "category": "html",
+    "tags": [
+      "button",
+      "html",
+      "skewed"
+    ],
+    "description": "Reusable skewed button snippet."
+  },
+  {
+    "name": "Skill Bar",
+    "path": "devsnips/snippets/html-snippets/skill-bar.html",
+    "category": "html",
+    "tags": [
+      "bar",
+      "html",
+      "skill"
+    ],
+    "description": "Reusable skill bar snippet."
+  },
+  {
+    "name": "Skip Link",
+    "path": "devsnips/snippets/html-snippets/skip-link.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "link",
+      "skip"
+    ],
+    "description": "Reusable skip link snippet."
+  },
+  {
+    "name": "Slide In From Left Effect",
+    "path": "devsnips/snippets/html-snippets/slide-in-from-left-effect.html",
+    "category": "html",
+    "tags": [
+      "effect",
+      "from",
+      "html",
+      "in",
+      "left",
+      "slide"
+    ],
+    "description": "Reusable slide in from left effect snippet."
+  },
+  {
+    "name": "Slide In From Right Effect",
+    "path": "devsnips/snippets/html-snippets/slide-in-from-right-effect.html",
+    "category": "html",
+    "tags": [
+      "effect",
+      "from",
+      "html",
+      "in",
+      "right",
+      "slide"
+    ],
+    "description": "Reusable slide in from right effect snippet."
+  },
+  {
+    "name": "Slide In Overlay",
+    "path": "devsnips/snippets/html-snippets/slide-in-overlay.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "in",
+      "overlay",
+      "slide"
+    ],
+    "description": "Reusable slide in overlay snippet."
+  },
+  {
+    "name": "Snippet 01 Responsive Navbar",
+    "path": "devsnips/snippets/html-snippets/snippet-01-responsive-navbar.html",
+    "category": "html",
+    "tags": [
+      "01",
+      "html",
+      "navbar",
+      "responsive",
+      "snippet"
+    ],
+    "description": "Reusable snippet 01 responsive navbar snippet."
+  },
+  {
+    "name": "Snippet 02 Sticky Header",
+    "path": "devsnips/snippets/html-snippets/snippet-02-sticky-header.html",
+    "category": "html",
+    "tags": [
+      "02",
+      "header",
+      "html",
+      "snippet",
+      "sticky"
+    ],
+    "description": "Reusable snippet 02 sticky header snippet."
+  },
+  {
+    "name": "Snippet 03 Mobile Dropdown",
+    "path": "devsnips/snippets/html-snippets/snippet-03-mobile-dropdown.html",
+    "category": "html",
+    "tags": [
+      "03",
+      "dropdown",
+      "html",
+      "mobile",
+      "snippet"
+    ],
+    "description": "Reusable snippet 03 mobile dropdown snippet."
+  },
+  {
+    "name": "Snippet 04 Accordion Faq",
+    "path": "devsnips/snippets/html-snippets/snippet-04-accordion-faq.html",
+    "category": "html",
+    "tags": [
+      "04",
+      "accordion",
+      "faq",
+      "html",
+      "snippet"
+    ],
+    "description": "Reusable snippet 04 accordion faq snippet."
+  },
+  {
+    "name": "Snippet 05 Tabbed Content",
+    "path": "devsnips/snippets/html-snippets/snippet-05-tabbed-content.html",
+    "category": "html",
+    "tags": [
+      "05",
+      "content",
+      "html",
+      "snippet",
+      "tabbed"
+    ],
+    "description": "Reusable snippet 05 tabbed content snippet."
+  },
+  {
+    "name": "Snippet 06 Dark Mode Toggle",
+    "path": "devsnips/snippets/html-snippets/snippet-06-dark-mode-toggle.html",
+    "category": "html",
+    "tags": [
+      "06",
+      "dark",
+      "html",
+      "mode",
+      "snippet",
+      "toggle"
+    ],
+    "description": "Reusable snippet 06 dark mode toggle snippet."
+  },
+  {
+    "name": "Snippet 07 Device Optimized Modal",
+    "path": "devsnips/snippets/html-snippets/snippet-07-device-optimized-modal.html",
+    "category": "html",
+    "tags": [
+      "07",
+      "device",
+      "html",
+      "modal",
+      "optimized",
+      "snippet"
+    ],
+    "description": "Reusable snippet 07 device optimized modal snippet."
+  },
+  {
+    "name": "Snippet 08 Toast Notification",
+    "path": "devsnips/snippets/html-snippets/snippet-08-toast-notification.html",
+    "category": "html",
+    "tags": [
+      "08",
+      "html",
+      "notification",
+      "snippet",
+      "toast"
+    ],
+    "description": "Reusable snippet 08 toast notification snippet."
+  },
+  {
+    "name": "Snippet 09 Floating Action Button",
+    "path": "devsnips/snippets/html-snippets/snippet-09-floating-action-button.html",
+    "category": "html",
+    "tags": [
+      "09",
+      "action",
+      "button",
+      "floating",
+      "html",
+      "snippet"
+    ],
+    "description": "Reusable snippet 09 floating action button snippet."
+  },
+  {
+    "name": "Snippet 10 Breadcrumb Nav",
+    "path": "devsnips/snippets/html-snippets/snippet-10-breadcrumb-nav.html",
+    "category": "html",
+    "tags": [
+      "10",
+      "breadcrumb",
+      "html",
+      "nav",
+      "snippet"
+    ],
+    "description": "Reusable snippet 10 breadcrumb nav snippet."
+  },
+  {
+    "name": "Snippet 11 Search Autocomplete",
+    "path": "devsnips/snippets/html-snippets/snippet-11-search-autocomplete.html",
+    "category": "html",
+    "tags": [
+      "11",
+      "autocomplete",
+      "html",
+      "search",
+      "snippet"
+    ],
+    "description": "Reusable snippet 11 search autocomplete snippet."
+  },
+  {
+    "name": "Snippet 12 Inline Form",
+    "path": "devsnips/snippets/html-snippets/snippet-12-inline-form.html",
+    "category": "html",
+    "tags": [
+      "12",
+      "form",
+      "html",
+      "inline",
+      "snippet"
+    ],
+    "description": "Reusable snippet 12 inline form snippet."
+  },
+  {
+    "name": "Snippet 13 Contact Form",
+    "path": "devsnips/snippets/html-snippets/snippet-13-contact-form.html",
+    "category": "html",
+    "tags": [
+      "13",
+      "contact",
+      "form",
+      "html",
+      "snippet"
+    ],
+    "description": "Reusable snippet 13 contact form snippet."
+  },
+  {
+    "name": "Snippet 14 Newsletter Signup",
+    "path": "devsnips/snippets/html-snippets/snippet-14-newsletter-signup.html",
+    "category": "html",
+    "tags": [
+      "14",
+      "html",
+      "newsletter",
+      "signup",
+      "snippet"
+    ],
+    "description": "Reusable snippet 14 newsletter signup snippet."
+  },
+  {
+    "name": "Snippet 15 Password Visibility Toggle",
+    "path": "devsnips/snippets/html-snippets/snippet-15-password-visibility-toggle.html",
+    "category": "html",
+    "tags": [
+      "15",
+      "html",
+      "password",
+      "snippet",
+      "toggle",
+      "visibility"
+    ],
+    "description": "Reusable snippet 15 password visibility toggle snippet."
+  },
+  {
+    "name": "Snippet 16 File Upload Input",
+    "path": "devsnips/snippets/html-snippets/snippet-16-file-upload-input.html",
+    "category": "html",
+    "tags": [
+      "16",
+      "file",
+      "html",
+      "input",
+      "snippet",
+      "upload"
+    ],
+    "description": "Reusable snippet 16 file upload input snippet."
+  },
+  {
+    "name": "Snippet 17 Rating Stars",
+    "path": "devsnips/snippets/html-snippets/snippet-17-rating-stars.html",
+    "category": "html",
+    "tags": [
+      "17",
+      "html",
+      "rating",
+      "snippet",
+      "stars"
+    ],
+    "description": "Reusable snippet 17 rating stars snippet."
+  },
+  {
+    "name": "Snippet 18 Date Time Picker",
+    "path": "devsnips/snippets/html-snippets/snippet-18-date-time-picker.html",
+    "category": "html",
+    "tags": [
+      "18",
+      "date",
+      "html",
+      "picker",
+      "snippet",
+      "time"
+    ],
+    "description": "Reusable snippet 18 date time picker snippet."
+  },
+  {
+    "name": "Social Buttons",
+    "path": "devsnips/snippets/html-snippets/social-buttons.html",
+    "category": "html",
+    "tags": [
+      "buttons",
+      "html",
+      "social"
+    ],
+    "description": "Reusable social buttons snippet."
+  },
+  {
+    "name": "Social Media Icons",
+    "path": "devsnips/snippets/html-snippets/social-media-icons.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "icons",
+      "media",
+      "social"
+    ],
+    "description": "Reusable social media icons snippet."
+  },
+  {
+    "name": "Social Media Share Links",
+    "path": "devsnips/snippets/html-snippets/social-media-share-links.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "links",
+      "media",
+      "share",
+      "social"
+    ],
+    "description": "Reusable social media share links snippet."
+  },
+  {
+    "name": "Spellcheck Attribute",
+    "path": "devsnips/snippets/html-snippets/spellcheck-attribute.html",
+    "category": "html",
+    "tags": [
+      "attribute",
+      "html",
+      "spellcheck"
+    ],
+    "description": "Reusable spellcheck attribute snippet."
+  },
+  {
+    "name": "Split Button",
+    "path": "devsnips/snippets/html-snippets/split-button.html",
+    "category": "html",
+    "tags": [
+      "button",
+      "html",
+      "split"
+    ],
+    "description": "Reusable split button snippet."
+  },
+  {
+    "name": "Split Screen",
+    "path": "devsnips/snippets/html-snippets/split-screen.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "screen",
+      "split"
+    ],
+    "description": "Reusable split screen snippet."
+  },
+  {
+    "name": "Staff Card",
+    "path": "devsnips/snippets/html-snippets/staff-card.html",
+    "category": "html",
+    "tags": [
+      "card",
+      "html",
+      "staff"
+    ],
+    "description": "Reusable staff card snippet."
+  },
+  {
+    "name": "Sticky Notes",
+    "path": "devsnips/snippets/html-snippets/sticky-notes.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "notes",
+      "sticky"
+    ],
+    "description": "Reusable sticky notes snippet."
+  },
+  {
+    "name": "Sticky Social Bar",
+    "path": "devsnips/snippets/html-snippets/sticky-social-bar.html",
+    "category": "html",
+    "tags": [
+      "bar",
+      "html",
+      "social",
+      "sticky"
+    ],
+    "description": "Reusable sticky social bar snippet."
+  },
+  {
+    "name": "Subscription Form",
+    "path": "devsnips/snippets/html-snippets/subscription-form.html",
+    "category": "html",
+    "tags": [
+      "form",
+      "html",
+      "subscription"
+    ],
+    "description": "Reusable subscription form snippet."
+  },
+  {
+    "name": "Svg Circle",
+    "path": "devsnips/snippets/html-snippets/svg-circle.html",
+    "category": "html",
+    "tags": [
+      "circle",
+      "html",
+      "svg"
+    ],
+    "description": "Reusable svg circle snippet."
+  },
+  {
+    "name": "Swing Animation",
+    "path": "devsnips/snippets/html-snippets/swing-animation.html",
+    "category": "html",
+    "tags": [
+      "animation",
+      "html",
+      "swing"
+    ],
+    "description": "Reusable swing animation snippet."
+  },
+  {
+    "name": "Table Caption",
+    "path": "devsnips/snippets/html-snippets/table-caption.html",
+    "category": "html",
+    "tags": [
+      "caption",
+      "html",
+      "table"
+    ],
+    "description": "Reusable table caption snippet."
+  },
+  {
+    "name": "Table Header Body Footer",
+    "path": "devsnips/snippets/html-snippets/table-header-body-footer.html",
+    "category": "html",
+    "tags": [
+      "body",
+      "footer",
+      "header",
+      "html",
+      "table"
+    ],
+    "description": "Reusable table header body footer snippet."
+  },
+  {
+    "name": "Table Merged Cells",
+    "path": "devsnips/snippets/html-snippets/table-merged-cells.html",
+    "category": "html",
+    "tags": [
+      "cells",
+      "html",
+      "merged",
+      "table"
+    ],
+    "description": "Reusable table merged cells snippet."
+  },
+  {
+    "name": "Table Scope",
+    "path": "devsnips/snippets/html-snippets/table-scope.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "scope",
+      "table"
+    ],
+    "description": "Reusable table scope snippet."
+  },
+  {
+    "name": "Tabs",
+    "path": "devsnips/snippets/html-snippets/tabs.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "tabs"
+    ],
+    "description": "Reusable tabs snippet."
+  },
+  {
+    "name": "Tada Animation",
+    "path": "devsnips/snippets/html-snippets/tada-animation.html",
+    "category": "html",
+    "tags": [
+      "animation",
+      "html",
+      "tada"
+    ],
+    "description": "Reusable tada animation snippet."
+  },
+  {
+    "name": "Template Element",
+    "path": "devsnips/snippets/html-snippets/template-element.html",
+    "category": "html",
+    "tags": [
+      "element",
+      "html",
+      "template"
+    ],
+    "description": "Reusable template element snippet."
+  },
+  {
+    "name": "Testimonial Slider",
+    "path": "devsnips/snippets/html-snippets/testimonial-slider.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "slider",
+      "testimonial"
+    ],
+    "description": "Reusable testimonial slider snippet."
+  },
+  {
+    "name": "Text Reveal On Hover",
+    "path": "devsnips/snippets/html-snippets/text-reveal-on-hover.html",
+    "category": "html",
+    "tags": [
+      "hover",
+      "html",
+      "on",
+      "reveal",
+      "text"
+    ],
+    "description": "Reusable text reveal on hover snippet."
+  },
+  {
+    "name": "Text With Background Image",
+    "path": "devsnips/snippets/html-snippets/text-with-background-image.html",
+    "category": "html",
+    "tags": [
+      "background",
+      "html",
+      "image",
+      "text",
+      "with"
+    ],
+    "description": "Reusable text with background image snippet."
+  },
+  {
+    "name": "Textarea Label",
+    "path": "devsnips/snippets/html-snippets/textarea-label.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "label",
+      "textarea"
+    ],
+    "description": "Reusable textarea label snippet."
+  },
+  {
+    "name": "Three Column Layout",
+    "path": "devsnips/snippets/html-snippets/three-column-layout.html",
+    "category": "html",
+    "tags": [
+      "column",
+      "html",
+      "layout",
+      "three"
+    ],
+    "description": "Reusable three column layout snippet."
+  },
+  {
+    "name": "Time Element",
+    "path": "devsnips/snippets/html-snippets/time-element.html",
+    "category": "html",
+    "tags": [
+      "element",
+      "html",
+      "time"
+    ],
+    "description": "Reusable time element snippet."
+  },
+  {
+    "name": "Timeline",
+    "path": "devsnips/snippets/html-snippets/timeline.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "timeline"
+    ],
+    "description": "Reusable timeline snippet."
+  },
+  {
+    "name": "Toast Notification Markup",
+    "path": "devsnips/snippets/html-snippets/toast-notification-markup.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "markup",
+      "notification",
+      "toast"
+    ],
+    "description": "Reusable toast notification markup snippet."
+  },
+  {
+    "name": "Tooltip Text",
+    "path": "devsnips/snippets/html-snippets/tooltip-text.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "text",
+      "tooltip"
+    ],
+    "description": "Reusable tooltip text snippet."
+  },
+  {
+    "name": "Top Navigation",
+    "path": "devsnips/snippets/html-snippets/top-navigation.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "navigation",
+      "top"
+    ],
+    "description": "Reusable top navigation snippet."
+  },
+  {
+    "name": "Two Column Layout",
+    "path": "devsnips/snippets/html-snippets/two-column-layout.html",
+    "category": "html",
+    "tags": [
+      "column",
+      "html",
+      "layout",
+      "two"
+    ],
+    "description": "Reusable two column layout snippet."
+  },
+  {
+    "name": "Typing Effect",
+    "path": "devsnips/snippets/html-snippets/typing-effect.html",
+    "category": "html",
+    "tags": [
+      "effect",
+      "html",
+      "typing"
+    ],
+    "description": "Reusable typing effect snippet."
+  },
+  {
+    "name": "User Rating",
+    "path": "devsnips/snippets/html-snippets/user-rating.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "rating",
+      "user"
+    ],
+    "description": "Reusable user rating snippet."
+  },
+  {
+    "name": "Vertical Menu",
+    "path": "devsnips/snippets/html-snippets/vertical-menu.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "menu",
+      "vertical"
+    ],
+    "description": "Reusable vertical menu snippet."
+  },
+  {
+    "name": "Video Background",
+    "path": "devsnips/snippets/html-snippets/video-background.html",
+    "category": "html",
+    "tags": [
+      "background",
+      "html",
+      "video"
+    ],
+    "description": "Reusable video background snippet."
+  },
+  {
+    "name": "Weather Widget",
+    "path": "devsnips/snippets/html-snippets/weather-widget.html",
+    "category": "html",
+    "tags": [
+      "html",
+      "weather",
+      "widget"
+    ],
+    "description": "Reusable weather widget snippet."
+  },
+  {
+    "name": "Wobble Animation",
+    "path": "devsnips/snippets/html-snippets/wobble-animation.html",
+    "category": "html",
+    "tags": [
+      "animation",
+      "html",
+      "wobble"
+    ],
+    "description": "Reusable wobble animation snippet."
+  },
+  {
+    "name": "Accordion",
+    "path": "devsnips/snippets/css-snippets/accordion.html",
+    "category": "css",
+    "tags": [
+      "accordion",
+      "css"
+    ],
+    "description": "Reusable accordion snippet."
+  },
+  {
+    "name": "Animated Gradient Border Button",
+    "path": "devsnips/snippets/css-snippets/animated-gradient-border-button.html",
+    "category": "css",
+    "tags": [
+      "animated",
+      "border",
+      "button",
+      "css",
+      "gradient"
+    ],
+    "description": "Reusable animated gradient border button snippet."
+  },
+  {
+    "name": "Animated Gradient Text",
+    "path": "devsnips/snippets/css-snippets/animated-gradient-text.css",
+    "category": "css",
+    "tags": [
+      "animated",
+      "css",
+      "gradient",
+      "text"
+    ],
+    "description": "Reusable animated gradient text snippet."
+  },
+  {
+    "name": "Animated Hamburger Menu",
+    "path": "devsnips/snippets/css-snippets/animated-hamburger-menu.css",
+    "category": "css",
+    "tags": [
+      "animated",
+      "css",
+      "hamburger",
+      "menu"
+    ],
+    "description": "Reusable animated hamburger menu snippet."
+  },
+  {
+    "name": "Animated Hamburger Menu",
+    "path": "devsnips/snippets/css-snippets/animated-hamburger-menu.html",
+    "category": "css",
+    "tags": [
+      "animated",
+      "css",
+      "hamburger",
+      "menu"
+    ],
+    "description": "Reusable animated hamburger menu snippet."
+  },
+  {
+    "name": "Aspect Ratio Boxes",
+    "path": "devsnips/snippets/css-snippets/aspect-ratio-boxes.html",
+    "category": "css",
+    "tags": [
+      "aspect",
+      "boxes",
+      "css",
+      "ratio"
+    ],
+    "description": "Reusable aspect ratio boxes snippet."
+  },
+  {
+    "name": "Auto Resizing Textarea",
+    "path": "devsnips/snippets/css-snippets/auto-resizing-textarea.css",
+    "category": "css",
+    "tags": [
+      "auto",
+      "css",
+      "resizing",
+      "textarea"
+    ],
+    "description": "Reusable auto resizing textarea snippet."
+  },
+  {
+    "name": "Bouncing Dots",
+    "path": "devsnips/snippets/css-snippets/bouncing-dots.html",
+    "category": "css",
+    "tags": [
+      "bouncing",
+      "css",
+      "dots"
+    ],
+    "description": "Reusable bouncing dots snippet."
+  },
+  {
+    "name": "Box Shadow Dual",
+    "path": "devsnips/snippets/css-snippets/box-shadow-dual.css",
+    "category": "css",
+    "tags": [
+      "box",
+      "css",
+      "dual",
+      "shadow"
+    ],
+    "description": "Reusable box shadow dual snippet."
+  },
+  {
+    "name": "Button Hover Glow",
+    "path": "devsnips/snippets/css-snippets/button-hover-glow.css",
+    "category": "css",
+    "tags": [
+      "button",
+      "css",
+      "glow",
+      "hover"
+    ],
+    "description": "Reusable button hover glow snippet."
+  },
+  {
+    "name": "Center Absolute",
+    "path": "devsnips/snippets/css-snippets/center-absolute.css",
+    "category": "css",
+    "tags": [
+      "absolute",
+      "center",
+      "css"
+    ],
+    "description": "Reusable center absolute snippet."
+  },
+  {
+    "name": "Center Anything Flexbox",
+    "path": "devsnips/snippets/css-snippets/center-anything-flexbox.html",
+    "category": "css",
+    "tags": [
+      "anything",
+      "center",
+      "css",
+      "flexbox"
+    ],
+    "description": "Reusable center anything flexbox snippet."
+  },
+  {
+    "name": "Center Anything Grid",
+    "path": "devsnips/snippets/css-snippets/center-anything-grid.html",
+    "category": "css",
+    "tags": [
+      "anything",
+      "center",
+      "css",
+      "grid"
+    ],
+    "description": "Reusable center anything grid snippet."
+  },
+  {
+    "name": "Centered Loader",
+    "path": "devsnips/snippets/css-snippets/centered-loader.html",
+    "category": "css",
+    "tags": [
+      "centered",
+      "css",
+      "loader"
+    ],
+    "description": "Reusable centered loader snippet."
+  },
+  {
+    "name": "Checkered Background",
+    "path": "devsnips/snippets/css-snippets/checkered-background.css",
+    "category": "css",
+    "tags": [
+      "background",
+      "checkered",
+      "css"
+    ],
+    "description": "Reusable checkered background snippet."
+  },
+  {
+    "name": "Clearfix Hack",
+    "path": "devsnips/snippets/css-snippets/clearfix-hack.css",
+    "category": "css",
+    "tags": [
+      "clearfix",
+      "css",
+      "hack"
+    ],
+    "description": "Reusable clearfix hack snippet."
+  },
+  {
+    "name": "Conditional Theming Container Query",
+    "path": "devsnips/snippets/css-snippets/conditional-theming-container-query.css",
+    "category": "css",
+    "tags": [
+      "conditional",
+      "container",
+      "css",
+      "query",
+      "theming"
+    ],
+    "description": "Reusable conditional theming container query snippet."
+  },
+  {
+    "name": "Conic Gradient Pie Chart",
+    "path": "devsnips/snippets/css-snippets/conic-gradient-pie-chart.css",
+    "category": "css",
+    "tags": [
+      "chart",
+      "conic",
+      "css",
+      "gradient",
+      "pie"
+    ],
+    "description": "Reusable conic gradient pie chart snippet."
+  },
+  {
+    "name": "Consistent Link Underline",
+    "path": "devsnips/snippets/css-snippets/consistent-link-underline.css",
+    "category": "css",
+    "tags": [
+      "consistent",
+      "css",
+      "link",
+      "underline"
+    ],
+    "description": "Reusable consistent link underline snippet."
+  },
+  {
+    "name": "Container Query Card",
+    "path": "devsnips/snippets/css-snippets/container-query-card.css",
+    "category": "css",
+    "tags": [
+      "card",
+      "container",
+      "css",
+      "query"
+    ],
+    "description": "Reusable container query card snippet."
+  },
+  {
+    "name": "Css Masonry Layout",
+    "path": "devsnips/snippets/css-snippets/css-masonry-layout.html",
+    "category": "css",
+    "tags": [
+      "css",
+      "layout",
+      "masonry"
+    ],
+    "description": "Reusable css masonry layout snippet."
+  },
+  {
+    "name": "Css Only Accordion",
+    "path": "devsnips/snippets/css-snippets/css-only-accordion.html",
+    "category": "css",
+    "tags": [
+      "accordion",
+      "css",
+      "only"
+    ],
+    "description": "Reusable css only accordion snippet."
+  },
+  {
+    "name": "Css Only Notification Badge",
+    "path": "devsnips/snippets/css-snippets/css-only-notification-badge.html",
+    "category": "css",
+    "tags": [
+      "badge",
+      "css",
+      "notification",
+      "only"
+    ],
+    "description": "Reusable css only notification badge snippet."
+  },
+  {
+    "name": "Css Only Progress Bar",
+    "path": "devsnips/snippets/css-snippets/css-only-progress-bar.html",
+    "category": "css",
+    "tags": [
+      "bar",
+      "css",
+      "only",
+      "progress"
+    ],
+    "description": "Reusable css only progress bar snippet."
+  },
+  {
+    "name": "Css Only Star Rating",
+    "path": "devsnips/snippets/css-snippets/css-only-star-rating.html",
+    "category": "css",
+    "tags": [
+      "css",
+      "only",
+      "rating",
+      "star"
+    ],
+    "description": "Reusable css only star rating snippet."
+  },
+  {
+    "name": "Css Only Toggle Switch",
+    "path": "devsnips/snippets/css-snippets/css-only-toggle-switch.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "only",
+      "switch",
+      "toggle"
+    ],
+    "description": "Reusable css only toggle switch snippet."
+  },
+  {
+    "name": "Css Only Tooltip",
+    "path": "devsnips/snippets/css-snippets/css-only-tooltip.html",
+    "category": "css",
+    "tags": [
+      "css",
+      "only",
+      "tooltip"
+    ],
+    "description": "Reusable css only tooltip snippet."
+  },
+  {
+    "name": "Css Triangle Shape",
+    "path": "devsnips/snippets/css-snippets/css-triangle-shape.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "shape",
+      "triangle"
+    ],
+    "description": "Reusable css triangle shape snippet."
+  },
+  {
+    "name": "Css Variable Fallback",
+    "path": "devsnips/snippets/css-snippets/css-variable-fallback.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "fallback",
+      "variable"
+    ],
+    "description": "Reusable css variable fallback snippet."
+  },
+  {
+    "name": "Custom Focus Ring",
+    "path": "devsnips/snippets/css-snippets/custom-focus-ring.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "custom",
+      "focus",
+      "ring"
+    ],
+    "description": "Reusable custom focus ring snippet."
+  },
+  {
+    "name": "Custom Scrollbar Webkit",
+    "path": "devsnips/snippets/css-snippets/custom-scrollbar-webkit.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "custom",
+      "scrollbar",
+      "webkit"
+    ],
+    "description": "Reusable custom scrollbar webkit snippet."
+  },
+  {
+    "name": "Dark Light Mode Theming",
+    "path": "devsnips/snippets/css-snippets/dark-light-mode-theming.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "dark",
+      "light",
+      "mode",
+      "theming"
+    ],
+    "description": "Reusable dark light mode theming snippet."
+  },
+  {
+    "name": "Dark Mode Css Variables",
+    "path": "devsnips/snippets/css-snippets/dark-mode-css-variables.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "dark",
+      "mode",
+      "variables"
+    ],
+    "description": "Reusable dark mode css variables snippet."
+  },
+  {
+    "name": "Direction Aware Hover",
+    "path": "devsnips/snippets/css-snippets/direction-aware-hover.css",
+    "category": "css",
+    "tags": [
+      "aware",
+      "css",
+      "direction",
+      "hover"
+    ],
+    "description": "Reusable direction aware hover snippet."
+  },
+  {
+    "name": "Disabled Element Style",
+    "path": "devsnips/snippets/css-snippets/disabled-element-style.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "disabled",
+      "element",
+      "style"
+    ],
+    "description": "Reusable disabled element style snippet."
+  },
+  {
+    "name": "Dotted Separator",
+    "path": "devsnips/snippets/css-snippets/dotted-separator.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "dotted",
+      "separator"
+    ],
+    "description": "Reusable dotted separator snippet."
+  },
+  {
+    "name": "Element Mask Clip Path",
+    "path": "devsnips/snippets/css-snippets/element-mask-clip-path.css",
+    "category": "css",
+    "tags": [
+      "clip",
+      "css",
+      "element",
+      "mask",
+      "path"
+    ],
+    "description": "Reusable element mask clip path snippet."
+  },
+  {
+    "name": "Equal Height Cards Flexbox",
+    "path": "devsnips/snippets/css-snippets/equal-height-cards-flexbox.html",
+    "category": "css",
+    "tags": [
+      "cards",
+      "css",
+      "equal",
+      "flexbox",
+      "height"
+    ],
+    "description": "Reusable equal height cards flexbox snippet."
+  },
+  {
+    "name": "Equal Height Cards Grid",
+    "path": "devsnips/snippets/css-snippets/equal-height-cards-grid.html",
+    "category": "css",
+    "tags": [
+      "cards",
+      "css",
+      "equal",
+      "grid",
+      "height"
+    ],
+    "description": "Reusable equal height cards grid snippet."
+  },
+  {
+    "name": "Fade In On Scroll",
+    "path": "devsnips/snippets/css-snippets/fade-in-on-scroll.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "fade",
+      "in",
+      "on",
+      "scroll"
+    ],
+    "description": "Reusable fade in on scroll snippet."
+  },
+  {
+    "name": "Flip Card",
+    "path": "devsnips/snippets/css-snippets/flip-card.html",
+    "category": "css",
+    "tags": [
+      "card",
+      "css",
+      "flip"
+    ],
+    "description": "Reusable flip card snippet."
+  },
+  {
+    "name": "Floating Label",
+    "path": "devsnips/snippets/css-snippets/floating-label.html",
+    "category": "css",
+    "tags": [
+      "css",
+      "floating",
+      "label"
+    ],
+    "description": "Reusable floating label snippet."
+  },
+  {
+    "name": "Focus Visible Accessibility",
+    "path": "devsnips/snippets/css-snippets/focus-visible-accessibility.css",
+    "category": "css",
+    "tags": [
+      "accessibility",
+      "css",
+      "focus",
+      "visible"
+    ],
+    "description": "Reusable focus visible accessibility snippet."
+  },
+  {
+    "name": "Frosted Glass Card",
+    "path": "devsnips/snippets/css-snippets/frosted-glass-card.html",
+    "category": "css",
+    "tags": [
+      "card",
+      "css",
+      "frosted",
+      "glass"
+    ],
+    "description": "Reusable frosted glass card snippet."
+  },
+  {
+    "name": "Frosted Glass Effect",
+    "path": "devsnips/snippets/css-snippets/frosted-glass-effect.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "effect",
+      "frosted",
+      "glass"
+    ],
+    "description": "Reusable frosted glass effect snippet."
+  },
+  {
+    "name": "Full Screen Overlay",
+    "path": "devsnips/snippets/css-snippets/full-screen-overlay.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "full",
+      "overlay",
+      "screen"
+    ],
+    "description": "Reusable full screen overlay snippet."
+  },
+  {
+    "name": "Future Css Color Contrast",
+    "path": "devsnips/snippets/css-snippets/future-css-color-contrast.css",
+    "category": "css",
+    "tags": [
+      "color",
+      "contrast",
+      "css",
+      "future"
+    ],
+    "description": "Reusable future css color contrast snippet."
+  },
+  {
+    "name": "Future Css Conditional If",
+    "path": "devsnips/snippets/css-snippets/future-css-conditional-if.css",
+    "category": "css",
+    "tags": [
+      "conditional",
+      "css",
+      "future",
+      "if"
+    ],
+    "description": "Reusable future css conditional if snippet."
+  },
+  {
+    "name": "Glassmorphism Card",
+    "path": "devsnips/snippets/css-snippets/glassmorphism-card.html",
+    "category": "css",
+    "tags": [
+      "card",
+      "css",
+      "glassmorphism"
+    ],
+    "description": "Reusable glassmorphism card snippet."
+  },
+  {
+    "name": "Global Box Sizing Reset",
+    "path": "devsnips/snippets/css-snippets/global-box-sizing-reset.css",
+    "category": "css",
+    "tags": [
+      "box",
+      "css",
+      "global",
+      "reset",
+      "sizing"
+    ],
+    "description": "Reusable global box sizing reset snippet."
+  },
+  {
+    "name": "Gradient Button",
+    "path": "devsnips/snippets/css-snippets/gradient-button.html",
+    "category": "css",
+    "tags": [
+      "button",
+      "css",
+      "gradient"
+    ],
+    "description": "Reusable gradient button snippet."
+  },
+  {
+    "name": "Has Selector Parent Styling",
+    "path": "devsnips/snippets/css-snippets/has-selector-parent-styling.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "has",
+      "parent",
+      "selector",
+      "styling"
+    ],
+    "description": "Reusable has selector parent styling snippet."
+  },
+  {
+    "name": "Hide Scrollbar Scrollable",
+    "path": "devsnips/snippets/css-snippets/hide-scrollbar-scrollable.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "hide",
+      "scrollable",
+      "scrollbar"
+    ],
+    "description": "Reusable hide scrollbar scrollable snippet."
+  },
+  {
+    "name": "Holy Grail Layout",
+    "path": "devsnips/snippets/css-snippets/holy-grail-layout.html",
+    "category": "css",
+    "tags": [
+      "css",
+      "grail",
+      "holy",
+      "layout"
+    ],
+    "description": "Reusable holy grail layout snippet."
+  },
+  {
+    "name": "Hover Reveal Overlay",
+    "path": "devsnips/snippets/css-snippets/hover-reveal-overlay.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "hover",
+      "overlay",
+      "reveal"
+    ],
+    "description": "Reusable hover reveal overlay snippet."
+  },
+  {
+    "name": "Mix Blend Mode Multiply",
+    "path": "devsnips/snippets/css-snippets/mix-blend-mode-multiply.css",
+    "category": "css",
+    "tags": [
+      "blend",
+      "css",
+      "mix",
+      "mode",
+      "multiply"
+    ],
+    "description": "Reusable mix blend mode multiply snippet."
+  },
+  {
+    "name": "Modal Dialog Backdrop",
+    "path": "devsnips/snippets/css-snippets/modal-dialog-backdrop.css",
+    "category": "css",
+    "tags": [
+      "backdrop",
+      "css",
+      "dialog",
+      "modal"
+    ],
+    "description": "Reusable modal dialog backdrop snippet."
+  },
+  {
+    "name": "Multi Line Clamp",
+    "path": "devsnips/snippets/css-snippets/multi-line-clamp.css",
+    "category": "css",
+    "tags": [
+      "clamp",
+      "css",
+      "line",
+      "multi"
+    ],
+    "description": "Reusable multi line clamp snippet."
+  },
+  {
+    "name": "Native Css Nesting",
+    "path": "devsnips/snippets/css-snippets/native-css-nesting.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "native",
+      "nesting"
+    ],
+    "description": "Reusable native css nesting snippet."
+  },
+  {
+    "name": "Neon Text",
+    "path": "devsnips/snippets/css-snippets/neon-text.html",
+    "category": "css",
+    "tags": [
+      "css",
+      "neon",
+      "text"
+    ],
+    "description": "Reusable neon text snippet."
+  },
+  {
+    "name": "Neumorphic Button Effect",
+    "path": "devsnips/snippets/css-snippets/neumorphic-button-effect.css",
+    "category": "css",
+    "tags": [
+      "button",
+      "css",
+      "effect",
+      "neumorphic"
+    ],
+    "description": "Reusable neumorphic button effect snippet."
+  },
+  {
+    "name": "Overlay Loader",
+    "path": "devsnips/snippets/css-snippets/overlay-loader.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "loader",
+      "overlay"
+    ],
+    "description": "Reusable overlay loader snippet."
+  },
+  {
+    "name": "Parallax Scrolling Effect",
+    "path": "devsnips/snippets/css-snippets/parallax-scrolling-effect.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "effect",
+      "parallax",
+      "scrolling"
+    ],
+    "description": "Reusable parallax scrolling effect snippet."
+  },
+  {
+    "name": "Prevent Text Selection",
+    "path": "devsnips/snippets/css-snippets/prevent-text-selection.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "prevent",
+      "selection",
+      "text"
+    ],
+    "description": "Reusable prevent text selection snippet."
+  },
+  {
+    "name": "Pulsing Animation",
+    "path": "devsnips/snippets/css-snippets/pulsing-animation.css",
+    "category": "css",
+    "tags": [
+      "animation",
+      "css",
+      "pulsing"
+    ],
+    "description": "Reusable pulsing animation snippet."
+  },
+  {
+    "name": "Responsive Embed",
+    "path": "devsnips/snippets/css-snippets/responsive-embed.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "embed",
+      "responsive"
+    ],
+    "description": "Reusable responsive embed snippet."
+  },
+  {
+    "name": "Responsive Grid System",
+    "path": "devsnips/snippets/css-snippets/responsive-grid-system.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "grid",
+      "responsive",
+      "system"
+    ],
+    "description": "Reusable responsive grid system snippet."
+  },
+  {
+    "name": "Responsive Hiding Utility",
+    "path": "devsnips/snippets/css-snippets/responsive-hiding-utility.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "hiding",
+      "responsive",
+      "utility"
+    ],
+    "description": "Reusable responsive hiding utility snippet."
+  },
+  {
+    "name": "Responsive Two Column Layout",
+    "path": "devsnips/snippets/css-snippets/responsive-two-column-layout.html",
+    "category": "css",
+    "tags": [
+      "column",
+      "css",
+      "layout",
+      "responsive",
+      "two"
+    ],
+    "description": "Reusable responsive two column layout snippet."
+  },
+  {
+    "name": "Responsive Video Container",
+    "path": "devsnips/snippets/css-snippets/responsive-video-container.html",
+    "category": "css",
+    "tags": [
+      "container",
+      "css",
+      "responsive",
+      "video"
+    ],
+    "description": "Reusable responsive video container snippet."
+  },
+  {
+    "name": "Scroll Snap Container",
+    "path": "devsnips/snippets/css-snippets/scroll-snap-container.css",
+    "category": "css",
+    "tags": [
+      "container",
+      "css",
+      "scroll",
+      "snap"
+    ],
+    "description": "Reusable scroll snap container snippet."
+  },
+  {
+    "name": "Simple Gradient Background",
+    "path": "devsnips/snippets/css-snippets/simple-gradient-background.css",
+    "category": "css",
+    "tags": [
+      "background",
+      "css",
+      "gradient",
+      "simple"
+    ],
+    "description": "Reusable simple gradient background snippet."
+  },
+  {
+    "name": "Skeleton Loader",
+    "path": "devsnips/snippets/css-snippets/skeleton-loader.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "loader",
+      "skeleton"
+    ],
+    "description": "Reusable skeleton loader snippet."
+  },
+  {
+    "name": "Smooth Scroll Behavior",
+    "path": "devsnips/snippets/css-snippets/smooth-scroll-behavior.css",
+    "category": "css",
+    "tags": [
+      "behavior",
+      "css",
+      "scroll",
+      "smooth"
+    ],
+    "description": "Reusable smooth scroll behavior snippet."
+  },
+  {
+    "name": "Snippet 01 Flexbox Center",
+    "path": "devsnips/snippets/css-snippets/snippet-01-flexbox-center.css",
+    "category": "css",
+    "tags": [
+      "01",
+      "center",
+      "css",
+      "flexbox",
+      "snippet"
+    ],
+    "description": "Reusable snippet 01 flexbox center snippet."
+  },
+  {
+    "name": "Snippet 02 Responsive Grid",
+    "path": "devsnips/snippets/css-snippets/snippet-02-responsive-grid.css",
+    "category": "css",
+    "tags": [
+      "02",
+      "css",
+      "grid",
+      "responsive",
+      "snippet"
+    ],
+    "description": "Reusable snippet 02 responsive grid snippet."
+  },
+  {
+    "name": "Snippet 03 Sticky Footer",
+    "path": "devsnips/snippets/css-snippets/snippet-03-sticky-footer.css",
+    "category": "css",
+    "tags": [
+      "03",
+      "css",
+      "footer",
+      "snippet",
+      "sticky"
+    ],
+    "description": "Reusable snippet 03 sticky footer snippet."
+  },
+  {
+    "name": "Snippet 04 Equal Height Cards",
+    "path": "devsnips/snippets/css-snippets/snippet-04-equal-height-cards.css",
+    "category": "css",
+    "tags": [
+      "04",
+      "cards",
+      "css",
+      "equal",
+      "height",
+      "snippet"
+    ],
+    "description": "Reusable snippet 04 equal height cards snippet."
+  },
+  {
+    "name": "Snippet 05 Fluid Typography",
+    "path": "devsnips/snippets/css-snippets/snippet-05-fluid-typography.css",
+    "category": "css",
+    "tags": [
+      "05",
+      "css",
+      "fluid",
+      "snippet",
+      "typography"
+    ],
+    "description": "Reusable snippet 05 fluid typography snippet."
+  },
+  {
+    "name": "Snippet 06 Responsive Container",
+    "path": "devsnips/snippets/css-snippets/snippet-06-responsive-container.css",
+    "category": "css",
+    "tags": [
+      "06",
+      "container",
+      "css",
+      "responsive",
+      "snippet"
+    ],
+    "description": "Reusable snippet 06 responsive container snippet."
+  },
+  {
+    "name": "Snippet 07 Split Screen",
+    "path": "devsnips/snippets/css-snippets/snippet-07-split-screen.css",
+    "category": "css",
+    "tags": [
+      "07",
+      "css",
+      "screen",
+      "snippet",
+      "split"
+    ],
+    "description": "Reusable snippet 07 split screen snippet."
+  },
+  {
+    "name": "Snippet 08 Masonry Layout",
+    "path": "devsnips/snippets/css-snippets/snippet-08-masonry-layout.css",
+    "category": "css",
+    "tags": [
+      "08",
+      "css",
+      "layout",
+      "masonry",
+      "snippet"
+    ],
+    "description": "Reusable snippet 08 masonry layout snippet."
+  },
+  {
+    "name": "Snippet 09 Aspect Ratio",
+    "path": "devsnips/snippets/css-snippets/snippet-09-aspect-ratio.css",
+    "category": "css",
+    "tags": [
+      "09",
+      "aspect",
+      "css",
+      "ratio",
+      "snippet"
+    ],
+    "description": "Reusable snippet 09 aspect ratio snippet."
+  },
+  {
+    "name": "Snippet 10 Sticky Sidebar",
+    "path": "devsnips/snippets/css-snippets/snippet-10-sticky-sidebar.css",
+    "category": "css",
+    "tags": [
+      "10",
+      "css",
+      "sidebar",
+      "snippet",
+      "sticky"
+    ],
+    "description": "Reusable snippet 10 sticky sidebar snippet."
+  },
+  {
+    "name": "Snippet 11 Hamburger Menu Animation",
+    "path": "devsnips/snippets/css-snippets/snippet-11-hamburger-menu-animation.css",
+    "category": "css",
+    "tags": [
+      "11",
+      "animation",
+      "css",
+      "hamburger",
+      "menu",
+      "snippet"
+    ],
+    "description": "Reusable snippet 11 hamburger menu animation snippet."
+  },
+  {
+    "name": "Snippet 12 Hover Dropdown",
+    "path": "devsnips/snippets/css-snippets/snippet-12-hover-dropdown.css",
+    "category": "css",
+    "tags": [
+      "12",
+      "css",
+      "dropdown",
+      "hover",
+      "snippet"
+    ],
+    "description": "Reusable snippet 12 hover dropdown snippet."
+  },
+  {
+    "name": "Snippet 13 Animated Underline",
+    "path": "devsnips/snippets/css-snippets/snippet-13-animated-underline.css",
+    "category": "css",
+    "tags": [
+      "13",
+      "animated",
+      "css",
+      "snippet",
+      "underline"
+    ],
+    "description": "Reusable snippet 13 animated underline snippet."
+  },
+  {
+    "name": "Snippet 14 Sticky Nav",
+    "path": "devsnips/snippets/css-snippets/snippet-14-sticky-nav.css",
+    "category": "css",
+    "tags": [
+      "14",
+      "css",
+      "nav",
+      "snippet",
+      "sticky"
+    ],
+    "description": "Reusable snippet 14 sticky nav snippet."
+  },
+  {
+    "name": "Snippet 15 Mobile Bottom Nav",
+    "path": "devsnips/snippets/css-snippets/snippet-15-mobile-bottom-nav.css",
+    "category": "css",
+    "tags": [
+      "15",
+      "bottom",
+      "css",
+      "mobile",
+      "nav",
+      "snippet"
+    ],
+    "description": "Reusable snippet 15 mobile bottom nav snippet."
+  },
+  {
+    "name": "Snippet 16 Gradient Button",
+    "path": "devsnips/snippets/css-snippets/snippet-16-gradient-button.css",
+    "category": "css",
+    "tags": [
+      "16",
+      "button",
+      "css",
+      "gradient",
+      "snippet"
+    ],
+    "description": "Reusable snippet 16 gradient button snippet."
+  },
+  {
+    "name": "Snippet 17 Icon Sidebar",
+    "path": "devsnips/snippets/css-snippets/snippet-17-icon-sidebar.css",
+    "category": "css",
+    "tags": [
+      "17",
+      "css",
+      "icon",
+      "sidebar",
+      "snippet"
+    ],
+    "description": "Reusable snippet 17 icon sidebar snippet."
+  },
+  {
+    "name": "Snippet 18 Css Tabs",
+    "path": "devsnips/snippets/css-snippets/snippet-18-css-tabs.css",
+    "category": "css",
+    "tags": [
+      "18",
+      "css",
+      "snippet",
+      "tabs"
+    ],
+    "description": "Reusable snippet 18 css tabs snippet."
+  },
+  {
+    "name": "Snippet 19 Sliding Indicator",
+    "path": "devsnips/snippets/css-snippets/snippet-19-sliding-indicator.css",
+    "category": "css",
+    "tags": [
+      "19",
+      "css",
+      "indicator",
+      "sliding",
+      "snippet"
+    ],
+    "description": "Reusable snippet 19 sliding indicator snippet."
+  },
+  {
+    "name": "Snippet 20 Glassmorphism Nav",
+    "path": "devsnips/snippets/css-snippets/snippet-20-glassmorphism-nav.css",
+    "category": "css",
+    "tags": [
+      "20",
+      "css",
+      "glassmorphism",
+      "nav",
+      "snippet"
+    ],
+    "description": "Reusable snippet 20 glassmorphism nav snippet."
+  },
+  {
+    "name": "Snippet 21 Neumorphic Button",
+    "path": "devsnips/snippets/css-snippets/snippet-21-neumorphic-button.css",
+    "category": "css",
+    "tags": [
+      "21",
+      "button",
+      "css",
+      "neumorphic",
+      "snippet"
+    ],
+    "description": "Reusable snippet 21 neumorphic button snippet."
+  },
+  {
+    "name": "Snippet 22 Ripple Effect",
+    "path": "devsnips/snippets/css-snippets/snippet-22-ripple-effect.css",
+    "category": "css",
+    "tags": [
+      "22",
+      "css",
+      "effect",
+      "ripple",
+      "snippet"
+    ],
+    "description": "Reusable snippet 22 ripple effect snippet."
+  },
+  {
+    "name": "Snippet 23 Fab Animation",
+    "path": "devsnips/snippets/css-snippets/snippet-23-fab-animation.css",
+    "category": "css",
+    "tags": [
+      "23",
+      "animation",
+      "css",
+      "fab",
+      "snippet"
+    ],
+    "description": "Reusable snippet 23 fab animation snippet."
+  },
+  {
+    "name": "Snippet 24 3D Press Button",
+    "path": "devsnips/snippets/css-snippets/snippet-24-3d-press-button.css",
+    "category": "css",
+    "tags": [
+      "24",
+      "3d",
+      "button",
+      "css",
+      "press",
+      "snippet"
+    ],
+    "description": "Reusable snippet 24 3d press button snippet."
+  },
+  {
+    "name": "Springy Easing Function",
+    "path": "devsnips/snippets/css-snippets/springy-easing-function.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "easing",
+      "function",
+      "springy"
+    ],
+    "description": "Reusable springy easing function snippet."
+  },
+  {
+    "name": "Sticky Footer",
+    "path": "devsnips/snippets/css-snippets/sticky-footer.html",
+    "category": "css",
+    "tags": [
+      "css",
+      "footer",
+      "sticky"
+    ],
+    "description": "Reusable sticky footer snippet."
+  },
+  {
+    "name": "Sticky Header",
+    "path": "devsnips/snippets/css-snippets/sticky-header.html",
+    "category": "css",
+    "tags": [
+      "css",
+      "header",
+      "sticky"
+    ],
+    "description": "Reusable sticky header snippet."
+  },
+  {
+    "name": "Subgrid Layout",
+    "path": "devsnips/snippets/css-snippets/subgrid-layout.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "layout",
+      "subgrid"
+    ],
+    "description": "Reusable subgrid layout snippet."
+  },
+  {
+    "name": "Text Wrap Balance",
+    "path": "devsnips/snippets/css-snippets/text-wrap-balance.css",
+    "category": "css",
+    "tags": [
+      "balance",
+      "css",
+      "text",
+      "wrap"
+    ],
+    "description": "Reusable text wrap balance snippet."
+  },
+  {
+    "name": "Toggle Switch",
+    "path": "devsnips/snippets/css-snippets/toggle-switch.html",
+    "category": "css",
+    "tags": [
+      "css",
+      "switch",
+      "toggle"
+    ],
+    "description": "Reusable toggle switch snippet."
+  },
+  {
+    "name": "Tooltip",
+    "path": "devsnips/snippets/css-snippets/tooltip.html",
+    "category": "css",
+    "tags": [
+      "css",
+      "tooltip"
+    ],
+    "description": "Reusable tooltip snippet."
+  },
+  {
+    "name": "Truncate Text Ellipsis",
+    "path": "devsnips/snippets/css-snippets/truncate-text-ellipsis.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "ellipsis",
+      "text",
+      "truncate"
+    ],
+    "description": "Reusable truncate text ellipsis snippet."
+  },
+  {
+    "name": "Typing Caret Animation",
+    "path": "devsnips/snippets/css-snippets/typing-caret-animation.css",
+    "category": "css",
+    "tags": [
+      "animation",
+      "caret",
+      "css",
+      "typing"
+    ],
+    "description": "Reusable typing caret animation snippet."
+  },
+  {
+    "name": "Underline Hover Link",
+    "path": "devsnips/snippets/css-snippets/underline-hover-link.html",
+    "category": "css",
+    "tags": [
+      "css",
+      "hover",
+      "link",
+      "underline"
+    ],
+    "description": "Reusable underline hover link snippet."
+  },
+  {
+    "name": "View Transitions Fade",
+    "path": "devsnips/snippets/css-snippets/view-transitions-fade.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "fade",
+      "transitions",
+      "view"
+    ],
+    "description": "Reusable view transitions fade snippet."
+  },
+  {
+    "name": "Visually Hidden",
+    "path": "devsnips/snippets/css-snippets/visually-hidden.css",
+    "category": "css",
+    "tags": [
+      "css",
+      "hidden",
+      "visually"
+    ],
+    "description": "Reusable visually hidden snippet."
+  },
+  {
+    "name": "Wavy Underline Text",
+    "path": "devsnips/snippets/css-snippets/wavy-underline-text.html",
+    "category": "css",
+    "tags": [
+      "css",
+      "text",
+      "underline",
+      "wavy"
+    ],
+    "description": "Reusable wavy underline text snippet."
+  },
+  {
+    "name": "Accessible Skip Link",
+    "path": "devsnips/snippets/js-snippets/Accessible Skip Link.html",
+    "category": "js",
+    "tags": [
+      "accessible",
+      "js",
+      "link",
+      "skip"
+    ],
+    "description": "Reusable accessible skip link snippet."
+  },
+  {
+    "name": "Css Toggle Switch",
+    "path": "devsnips/snippets/js-snippets/CSS Toggle Switch.html",
+    "category": "js",
+    "tags": [
+      "css",
+      "js",
+      "switch",
+      "toggle"
+    ],
+    "description": "Reusable css toggle switch snippet."
+  },
+  {
+    "name": "Debounced Input Handler (Js)",
+    "path": "devsnips/snippets/js-snippets/Debounced Input Handler (JS).js",
+    "category": "js",
+    "tags": [
+      "(js)",
+      "debounced",
+      "handler",
+      "input",
+      "js"
+    ],
+    "description": "Reusable debounced input handler (js) snippet."
+  },
+  {
+    "name": "Fetch Wrapper With Timeout",
+    "path": "devsnips/snippets/js-snippets/Fetch Wrapper with Timeout.js",
+    "category": "js",
+    "tags": [
+      "fetch",
+      "js",
+      "timeout",
+      "with",
+      "wrapper"
+    ],
+    "description": "Reusable fetch wrapper with timeout snippet."
+  },
+  {
+    "name": "Focus Trap (Modal)",
+    "path": "devsnips/snippets/js-snippets/Focus Trap (modal).js",
+    "category": "js",
+    "tags": [
+      "(modal)",
+      "focus",
+      "js",
+      "trap"
+    ],
+    "description": "Reusable focus trap (modal) snippet."
+  },
+  {
+    "name": "Localstorage Json Helpers",
+    "path": "devsnips/snippets/js-snippets/LocalStorage JSON Helpers.js",
+    "category": "js",
+    "tags": [
+      "helpers",
+      "js",
+      "json",
+      "localstorage"
+    ],
+    "description": "Reusable localstorage json helpers snippet."
+  },
+  {
+    "name": "Progressive Image (Blur Up)",
+    "path": "devsnips/snippets/js-snippets/Progressive Image (blur-up).html",
+    "category": "js",
+    "tags": [
+      "(blur",
+      "image",
+      "js",
+      "progressive",
+      "up)"
+    ],
+    "description": "Reusable progressive image (blur up) snippet."
+  },
+  {
+    "name": "Responsive Sticky Header With Shadow",
+    "path": "devsnips/snippets/js-snippets/Responsive Sticky Header with Shadow.html",
+    "category": "js",
+    "tags": [
+      "header",
+      "js",
+      "responsive",
+      "shadow",
+      "sticky",
+      "with"
+    ],
+    "description": "Reusable responsive sticky header with shadow snippet."
+  },
+  {
+    "name": "Accordion Panel",
+    "path": "devsnips/snippets/js-snippets/accordion-panel.html",
+    "category": "js",
+    "tags": [
+      "accordion",
+      "js",
+      "panel"
+    ],
+    "description": "Reusable accordion panel snippet."
+  },
+  {
+    "name": "Average Of Numbers",
+    "path": "devsnips/snippets/js-snippets/average-of-numbers.js",
+    "category": "js",
+    "tags": [
+      "average",
+      "js",
+      "numbers",
+      "of"
+    ],
+    "description": "Reusable average of numbers snippet."
+  },
+  {
+    "name": "Capitalize String",
+    "path": "devsnips/snippets/js-snippets/capitalize-string.js",
+    "category": "js",
+    "tags": [
+      "capitalize",
+      "js",
+      "string"
+    ],
+    "description": "Reusable capitalize string snippet."
+  },
+  {
+    "name": "Character Counter",
+    "path": "devsnips/snippets/js-snippets/character-counter.html",
+    "category": "js",
+    "tags": [
+      "character",
+      "counter",
+      "js"
+    ],
+    "description": "Reusable character counter snippet."
+  },
+  {
+    "name": "Check For Touch Support",
+    "path": "devsnips/snippets/js-snippets/check-for-touch-support.js",
+    "category": "js",
+    "tags": [
+      "check",
+      "for",
+      "js",
+      "support",
+      "touch"
+    ],
+    "description": "Reusable check for touch support snippet."
+  },
+  {
+    "name": "Clipboard Copy Helper",
+    "path": "devsnips/snippets/js-snippets/clipboard-copy-helper.js",
+    "category": "js",
+    "tags": [
+      "clipboard",
+      "copy",
+      "helper",
+      "js"
+    ],
+    "description": "Reusable clipboard copy helper snippet."
+  },
+  {
+    "name": "Clone Array",
+    "path": "devsnips/snippets/js-snippets/clone-array.js",
+    "category": "js",
+    "tags": [
+      "array",
+      "clone",
+      "js"
+    ],
+    "description": "Reusable clone array snippet."
+  },
+  {
+    "name": "Convert Array Of Strings To Uppercase",
+    "path": "devsnips/snippets/js-snippets/convert-array-of-strings-to-uppercase.js",
+    "category": "js",
+    "tags": [
+      "array",
+      "convert",
+      "js",
+      "of",
+      "strings",
+      "to",
+      "uppercase"
+    ],
+    "description": "Reusable convert array of strings to uppercase snippet."
+  },
+  {
+    "name": "Copy Text To Clipboard",
+    "path": "devsnips/snippets/js-snippets/copy-text-to-clipboard.js",
+    "category": "js",
+    "tags": [
+      "clipboard",
+      "copy",
+      "js",
+      "text",
+      "to"
+    ],
+    "description": "Reusable copy text to clipboard snippet."
+  },
+  {
+    "name": "Copy To Clipboard",
+    "path": "devsnips/snippets/js-snippets/copy-to-clipboard.html",
+    "category": "js",
+    "tags": [
+      "clipboard",
+      "copy",
+      "js",
+      "to"
+    ],
+    "description": "Reusable copy to clipboard snippet."
+  },
+  {
+    "name": "Dark Mode Toggle",
+    "path": "devsnips/snippets/js-snippets/dark-mode-toggle.html",
+    "category": "js",
+    "tags": [
+      "dark",
+      "js",
+      "mode",
+      "toggle"
+    ],
+    "description": "Reusable dark mode toggle snippet."
+  },
+  {
+    "name": "Day Of Year",
+    "path": "devsnips/snippets/js-snippets/day-of-year.js",
+    "category": "js",
+    "tags": [
+      "day",
+      "js",
+      "of",
+      "year"
+    ],
+    "description": "Reusable day of year snippet."
+  },
+  {
+    "name": "Debounce Utility",
+    "path": "devsnips/snippets/js-snippets/debounce-utility.js",
+    "category": "js",
+    "tags": [
+      "debounce",
+      "js",
+      "utility"
+    ],
+    "description": "Reusable debounce utility snippet."
+  },
+  {
+    "name": "Deep Clone Object",
+    "path": "devsnips/snippets/js-snippets/deep-clone-object.js",
+    "category": "js",
+    "tags": [
+      "clone",
+      "deep",
+      "js",
+      "object"
+    ],
+    "description": "Reusable deep clone object snippet."
+  },
+  {
+    "name": "Flatten Array",
+    "path": "devsnips/snippets/js-snippets/flatten-array.js",
+    "category": "js",
+    "tags": [
+      "array",
+      "flatten",
+      "js"
+    ],
+    "description": "Reusable flatten array snippet."
+  },
+  {
+    "name": "Form Validation",
+    "path": "devsnips/snippets/js-snippets/form-validation.html",
+    "category": "js",
+    "tags": [
+      "form",
+      "js",
+      "validation"
+    ],
+    "description": "Reusable form validation snippet."
+  },
+  {
+    "name": "Form Validator",
+    "path": "devsnips/snippets/js-snippets/form-validator.js",
+    "category": "js",
+    "tags": [
+      "form",
+      "js",
+      "validator"
+    ],
+    "description": "Reusable form validator snippet."
+  },
+  {
+    "name": "Generate Random Hex Color",
+    "path": "devsnips/snippets/js-snippets/generate-random-hex-color.js",
+    "category": "js",
+    "tags": [
+      "color",
+      "generate",
+      "hex",
+      "js",
+      "random"
+    ],
+    "description": "Reusable generate random hex color snippet."
+  },
+  {
+    "name": "Get Cookie Value",
+    "path": "devsnips/snippets/js-snippets/get-cookie-value.js",
+    "category": "js",
+    "tags": [
+      "cookie",
+      "get",
+      "js",
+      "value"
+    ],
+    "description": "Reusable get cookie value snippet."
+  },
+  {
+    "name": "Get Current Timestamp",
+    "path": "devsnips/snippets/js-snippets/get-current-timestamp.js",
+    "category": "js",
+    "tags": [
+      "current",
+      "get",
+      "js",
+      "timestamp"
+    ],
+    "description": "Reusable get current timestamp snippet."
+  },
+  {
+    "name": "Get Max From Array",
+    "path": "devsnips/snippets/js-snippets/get-max-from-array.js",
+    "category": "js",
+    "tags": [
+      "array",
+      "from",
+      "get",
+      "js",
+      "max"
+    ],
+    "description": "Reusable get max from array snippet."
+  },
+  {
+    "name": "Get Min From Array",
+    "path": "devsnips/snippets/js-snippets/get-min-from-array.js",
+    "category": "js",
+    "tags": [
+      "array",
+      "from",
+      "get",
+      "js",
+      "min"
+    ],
+    "description": "Reusable get min from array snippet."
+  },
+  {
+    "name": "Get Random Element From Array",
+    "path": "devsnips/snippets/js-snippets/get-random-element-from-array.js",
+    "category": "js",
+    "tags": [
+      "array",
+      "element",
+      "from",
+      "get",
+      "js",
+      "random"
+    ],
+    "description": "Reusable get random element from array snippet."
+  },
+  {
+    "name": "Get Random Number In Range",
+    "path": "devsnips/snippets/js-snippets/get-random-number-in-range.js",
+    "category": "js",
+    "tags": [
+      "get",
+      "in",
+      "js",
+      "number",
+      "random",
+      "range"
+    ],
+    "description": "Reusable get random number in range snippet."
+  },
+  {
+    "name": "Get Time From Date",
+    "path": "devsnips/snippets/js-snippets/get-time-from-date.js",
+    "category": "js",
+    "tags": [
+      "date",
+      "from",
+      "get",
+      "js",
+      "time"
+    ],
+    "description": "Reusable get time from date snippet."
+  },
+  {
+    "name": "Get Unique Values From Array",
+    "path": "devsnips/snippets/js-snippets/get-unique-values-from-array.js",
+    "category": "js",
+    "tags": [
+      "array",
+      "from",
+      "get",
+      "js",
+      "unique",
+      "values"
+    ],
+    "description": "Reusable get unique values from array snippet."
+  },
+  {
+    "name": "Get Url Parameters",
+    "path": "devsnips/snippets/js-snippets/get-url-parameters.js",
+    "category": "js",
+    "tags": [
+      "get",
+      "js",
+      "parameters",
+      "url"
+    ],
+    "description": "Reusable get url parameters snippet."
+  },
+  {
+    "name": "Has Duplicates In Array",
+    "path": "devsnips/snippets/js-snippets/has-duplicates-in-array.js",
+    "category": "js",
+    "tags": [
+      "array",
+      "duplicates",
+      "has",
+      "in",
+      "js"
+    ],
+    "description": "Reusable has duplicates in array snippet."
+  },
+  {
+    "name": "Image Slider",
+    "path": "devsnips/snippets/js-snippets/image-slider.html",
+    "category": "js",
+    "tags": [
+      "image",
+      "js",
+      "slider"
+    ],
+    "description": "Reusable image slider snippet."
+  },
+  {
+    "name": "Is Apple Device",
+    "path": "devsnips/snippets/js-snippets/is-apple-device.js",
+    "category": "js",
+    "tags": [
+      "apple",
+      "device",
+      "is",
+      "js"
+    ],
+    "description": "Reusable is apple device snippet."
+  },
+  {
+    "name": "Is Array Empty",
+    "path": "devsnips/snippets/js-snippets/is-array-empty.js",
+    "category": "js",
+    "tags": [
+      "array",
+      "empty",
+      "is",
+      "js"
+    ],
+    "description": "Reusable is array empty snippet."
+  },
+  {
+    "name": "Is Array",
+    "path": "devsnips/snippets/js-snippets/is-array.js",
+    "category": "js",
+    "tags": [
+      "array",
+      "is",
+      "js"
+    ],
+    "description": "Reusable is array snippet."
+  },
+  {
+    "name": "Is Boolean",
+    "path": "devsnips/snippets/js-snippets/is-boolean.js",
+    "category": "js",
+    "tags": [
+      "boolean",
+      "is",
+      "js"
+    ],
+    "description": "Reusable is boolean snippet."
+  },
+  {
+    "name": "Is Browser Tab In View",
+    "path": "devsnips/snippets/js-snippets/is-browser-tab-in-view.js",
+    "category": "js",
+    "tags": [
+      "browser",
+      "in",
+      "is",
+      "js",
+      "tab",
+      "view"
+    ],
+    "description": "Reusable is browser tab in view snippet."
+  },
+  {
+    "name": "Is Browser",
+    "path": "devsnips/snippets/js-snippets/is-browser.js",
+    "category": "js",
+    "tags": [
+      "browser",
+      "is",
+      "js"
+    ],
+    "description": "Reusable is browser snippet."
+  },
+  {
+    "name": "Is Date Valid",
+    "path": "devsnips/snippets/js-snippets/is-date-valid.js",
+    "category": "js",
+    "tags": [
+      "date",
+      "is",
+      "js",
+      "valid"
+    ],
+    "description": "Reusable is date valid snippet."
+  },
+  {
+    "name": "Is Even",
+    "path": "devsnips/snippets/js-snippets/is-even.js",
+    "category": "js",
+    "tags": [
+      "even",
+      "is",
+      "js"
+    ],
+    "description": "Reusable is even snippet."
+  },
+  {
+    "name": "Is Function",
+    "path": "devsnips/snippets/js-snippets/is-function.js",
+    "category": "js",
+    "tags": [
+      "function",
+      "is",
+      "js"
+    ],
+    "description": "Reusable is function snippet."
+  },
+  {
+    "name": "Is Node",
+    "path": "devsnips/snippets/js-snippets/is-node.js",
+    "category": "js",
+    "tags": [
+      "is",
+      "js",
+      "node"
+    ],
+    "description": "Reusable is node snippet."
+  },
+  {
+    "name": "Is Null",
+    "path": "devsnips/snippets/js-snippets/is-null.js",
+    "category": "js",
+    "tags": [
+      "is",
+      "js",
+      "null"
+    ],
+    "description": "Reusable is null snippet."
+  },
+  {
+    "name": "Is Number",
+    "path": "devsnips/snippets/js-snippets/is-number.js",
+    "category": "js",
+    "tags": [
+      "is",
+      "js",
+      "number"
+    ],
+    "description": "Reusable is number snippet."
+  },
+  {
+    "name": "Is Object Empty",
+    "path": "devsnips/snippets/js-snippets/is-object-empty.js",
+    "category": "js",
+    "tags": [
+      "empty",
+      "is",
+      "js",
+      "object"
+    ],
+    "description": "Reusable is object empty snippet."
+  },
+  {
+    "name": "Is Object",
+    "path": "devsnips/snippets/js-snippets/is-object.js",
+    "category": "js",
+    "tags": [
+      "is",
+      "js",
+      "object"
+    ],
+    "description": "Reusable is object snippet."
+  },
+  {
+    "name": "Is Promise",
+    "path": "devsnips/snippets/js-snippets/is-promise.js",
+    "category": "js",
+    "tags": [
+      "is",
+      "js",
+      "promise"
+    ],
+    "description": "Reusable is promise snippet."
+  },
+  {
+    "name": "Is String",
+    "path": "devsnips/snippets/js-snippets/is-string.js",
+    "category": "js",
+    "tags": [
+      "is",
+      "js",
+      "string"
+    ],
+    "description": "Reusable is string snippet."
+  },
+  {
+    "name": "Is Undefined",
+    "path": "devsnips/snippets/js-snippets/is-undefined.js",
+    "category": "js",
+    "tags": [
+      "is",
+      "js",
+      "undefined"
+    ],
+    "description": "Reusable is undefined snippet."
+  },
+  {
+    "name": "Is Valid Json",
+    "path": "devsnips/snippets/js-snippets/is-valid-json.js",
+    "category": "js",
+    "tags": [
+      "is",
+      "js",
+      "json",
+      "valid"
+    ],
+    "description": "Reusable is valid json snippet."
+  },
+  {
+    "name": "Is Weekday",
+    "path": "devsnips/snippets/js-snippets/is-weekday.js",
+    "category": "js",
+    "tags": [
+      "is",
+      "js",
+      "weekday"
+    ],
+    "description": "Reusable is weekday snippet."
+  },
+  {
+    "name": "Is Weekend",
+    "path": "devsnips/snippets/js-snippets/is-weekend.js",
+    "category": "js",
+    "tags": [
+      "is",
+      "js",
+      "weekend"
+    ],
+    "description": "Reusable is weekend snippet."
+  },
+  {
+    "name": "Lazy Image Loader",
+    "path": "devsnips/snippets/js-snippets/lazy-image-loader.js",
+    "category": "js",
+    "tags": [
+      "image",
+      "js",
+      "lazy",
+      "loader"
+    ],
+    "description": "Reusable lazy image loader snippet."
+  },
+  {
+    "name": "Local Storage Wrapper",
+    "path": "devsnips/snippets/js-snippets/local-storage-wrapper.js",
+    "category": "js",
+    "tags": [
+      "js",
+      "local",
+      "storage",
+      "wrapper"
+    ],
+    "description": "Reusable local storage wrapper snippet."
+  },
+  {
+    "name": "Modal Popup",
+    "path": "devsnips/snippets/js-snippets/modal-popup.html",
+    "category": "js",
+    "tags": [
+      "js",
+      "modal",
+      "popup"
+    ],
+    "description": "Reusable modal popup snippet."
+  },
+  {
+    "name": "Redirect To Url",
+    "path": "devsnips/snippets/js-snippets/redirect-to-url.js",
+    "category": "js",
+    "tags": [
+      "js",
+      "redirect",
+      "to",
+      "url"
+    ],
+    "description": "Reusable redirect to url snippet."
+  },
+  {
+    "name": "Remove Duplicates From Array",
+    "path": "devsnips/snippets/js-snippets/remove-duplicates-from-array.js",
+    "category": "js",
+    "tags": [
+      "array",
+      "duplicates",
+      "from",
+      "js",
+      "remove"
+    ],
+    "description": "Reusable remove duplicates from array snippet."
+  },
+  {
+    "name": "Remove Falsy Values From Array",
+    "path": "devsnips/snippets/js-snippets/remove-falsy-values-from-array.js",
+    "category": "js",
+    "tags": [
+      "array",
+      "falsy",
+      "from",
+      "js",
+      "remove",
+      "values"
+    ],
+    "description": "Reusable remove falsy values from array snippet."
+  },
+  {
+    "name": "Remove Html Tags",
+    "path": "devsnips/snippets/js-snippets/remove-html-tags.js",
+    "category": "js",
+    "tags": [
+      "html",
+      "js",
+      "remove",
+      "tags"
+    ],
+    "description": "Reusable remove html tags snippet."
+  },
+  {
+    "name": "Rgb To Hex",
+    "path": "devsnips/snippets/js-snippets/rgb-to-hex.js",
+    "category": "js",
+    "tags": [
+      "hex",
+      "js",
+      "rgb",
+      "to"
+    ],
+    "description": "Reusable rgb to hex snippet."
+  },
+  {
+    "name": "Scroll To Top Of Page",
+    "path": "devsnips/snippets/js-snippets/scroll-to-top-of-page.js",
+    "category": "js",
+    "tags": [
+      "js",
+      "of",
+      "page",
+      "scroll",
+      "to",
+      "top"
+    ],
+    "description": "Reusable scroll to top of page snippet."
+  },
+  {
+    "name": "Scroll To Top",
+    "path": "devsnips/snippets/js-snippets/scroll-to-top.html",
+    "category": "js",
+    "tags": [
+      "js",
+      "scroll",
+      "to",
+      "top"
+    ],
+    "description": "Reusable scroll to top snippet."
+  },
+  {
+    "name": "Shuffle Array",
+    "path": "devsnips/snippets/js-snippets/shuffle-array.js",
+    "category": "js",
+    "tags": [
+      "array",
+      "js",
+      "shuffle"
+    ],
+    "description": "Reusable shuffle array snippet."
+  },
+  {
+    "name": "Sum All Numbers In Array",
+    "path": "devsnips/snippets/js-snippets/sum-all-numbers-in-array.js",
+    "category": "js",
+    "tags": [
+      "all",
+      "array",
+      "in",
+      "js",
+      "numbers",
+      "sum"
+    ],
+    "description": "Reusable sum all numbers in array snippet."
+  },
+  {
+    "name": "Tabs Component",
+    "path": "devsnips/snippets/js-snippets/tabs-component.html",
+    "category": "js",
+    "tags": [
+      "component",
+      "js",
+      "tabs"
+    ],
+    "description": "Reusable tabs component snippet."
+  },
+  {
+    "name": "Toast Notification",
+    "path": "devsnips/snippets/js-snippets/toast-notification.html",
+    "category": "js",
+    "tags": [
+      "js",
+      "notification",
+      "toast"
+    ],
+    "description": "Reusable toast notification snippet."
+  },
+  {
+    "name": "Toggle Element Visibility",
+    "path": "devsnips/snippets/js-snippets/toggle-element-visibility.js",
+    "category": "js",
+    "tags": [
+      "element",
+      "js",
+      "toggle",
+      "visibility"
+    ],
+    "description": "Reusable toggle element visibility snippet."
+  },
+  {
+    "name": "Truncate String",
+    "path": "devsnips/snippets/js-snippets/truncate-string.js",
+    "category": "js",
+    "tags": [
+      "js",
+      "string",
+      "truncate"
+    ],
+    "description": "Reusable truncate string snippet."
+  }
+]


### PR DESCRIPTION
### Motivation
- Improve consistency, discoverability, and accessibility across the snippet library by adding standard metadata and headers to all snippets.  
- Provide commonly requested, ready-to-use snippets (modal, accordion, pricing card, skeleton loader, toast, debounce, clipboard helper, etc.) to fill gaps in the collection.  
- Add basic CI linting and editor settings to enforce formatting and reduce regressions.  

### Description
- Added a standardized comment header to every snippet in `devsnips/snippets/html-snippets`, `devsnips/snippets/css-snippets`, and `devsnips/snippets/js-snippets` (385 files updated).  
- Added new HTML snippets: `modal-dialog.html`, `accordion-faq-layout.html`, `pricing-card.html`, `skeleton-loader.html`, and `toast-notification-markup.html`.  
- Added new CSS snippets: `dark-mode-css-variables.css`, `responsive-grid-system.css`, `animated-hamburger-menu.css`, and `focus-visible-accessibility.css`.  
- Added new JS snippets: `debounce-utility.js`, `clipboard-copy-helper.js`, `local-storage-wrapper.js`, `form-validator.js`, and `lazy-image-loader.js`.  
- Generated `snippets-index.json` at repository root listing every snippet with `name`, `path`, `category`, `tags`, and `description`.  
- Rewrote `README.md` with live demo badge, contribution badges, a clear “How to use” section, and a full snippet table; updated `CONTRIBUTING.md` and `PULL_REQUEST_TEMPLATE.md` with style rules and contributor checklist.  
- Added project tooling/config: `.editorconfig`, `.htmlhintrc`, `eslint.config.js`, `CHANGELOG.md`, and a GitHub Actions workflow at `.github/workflows/lint.yml` to run `HTMLHint` and `ESLint` on PRs/pushes.  

### Testing
- Ran a Python verification script that confirmed every snippet file now begins with a comment header (result: `total 385 with_header 385`).  
- Executed `npx --yes eslint "devsnips/snippets/js-snippets/**/*.js"` in this environment and it completed successfully (with an npm env-config warning).  
- Attempted `npx --yes htmlhint "devsnips/snippets/**/*.html"` but it failed to download `htmlhint` due to a registry `403 Forbidden` in this environment; workflow configuration is included for CI where the runner can access npm.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afbc34b308832983bc941cc001c8b4)