### PR TITLE
Redesign snippets landing page layout and styling

### DIFF
--- a/devsnips/assets/css/styles.css
+++ b/devsnips/assets/css/styles.css
@@ -1,0 +1,144 @@
+:root {
+  --bg: #0b1020;
+  --panel: #121a31;
+  --panel-soft: #182241;
+  --text: #e8ecff;
+  --muted: #b8c1ea;
+  --accent: #74a4ff;
+  --accent-2: #6ee7d9;
+  --border: rgba(174, 191, 255, 0.2);
+  --radius: 16px;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: Inter, "Segoe UI", Roboto, system-ui, sans-serif;
+  background: radial-gradient(circle at top right, #1a2752 0%, var(--bg) 50%);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  backdrop-filter: blur(10px);
+  background: rgba(11, 16, 32, 0.75);
+  z-index: 10;
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+  gap: 1rem;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.brand h1 { margin: 0; font-size: 1.25rem; }
+.brand p { margin: 0; color: var(--muted); font-size: 0.95rem; }
+
+.nav-list {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-list a {
+  text-decoration: none;
+  color: var(--text);
+  padding: 0.45rem 0.8rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+}
+
+.nav-list a:hover {
+  border-color: var(--border);
+  background: rgba(255,255,255,0.04);
+}
+
+.hero {
+  padding: 4rem 0 2rem;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 1.5rem;
+}
+
+.hero-card,
+.category-card,
+.quick-links {
+  background: linear-gradient(180deg, var(--panel-soft), var(--panel));
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.hero-card { padding: 2rem; }
+.hero-card h2 { margin-top: 0; font-size: clamp(1.5rem, 2.8vw, 2.5rem); line-height: 1.2; }
+.hero-card p { color: var(--muted); max-width: 58ch; }
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.badges span {
+  background: rgba(116, 164, 255, 0.16);
+  border: 1px solid rgba(116, 164, 255, 0.4);
+  color: #cfe0ff;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.quick-links { padding: 1.5rem; }
+.quick-links h3 { margin-top: 0; }
+.quick-links ul { margin: 0; padding-left: 1rem; }
+.quick-links a { color: var(--accent-2); }
+
+.snippets-section { padding: 1rem 0 3rem; }
+.section-title { margin-bottom: 1rem; }
+
+.snippet-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.category-card { padding: 1.25rem; }
+.category-card h4 { margin: 0 0 0.4rem; }
+.category-card p { margin: 0 0 0.75rem; color: var(--muted); }
+.category-card a { color: var(--accent); font-weight: 600; text-decoration: none; }
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 1.2rem 0;
+  color: var(--muted);
+  text-align: center;
+}
+
+@media (max-width: 800px) {
+  .header-inner { flex-direction: column; align-items: flex-start; }
+  .hero-grid { grid-template-columns: 1fr; }
+}

--- a/devsnips/index.html
+++ b/devsnips/index.html
@@ -4,79 +4,84 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>DevSnips – Code Snippets Library</title>
+  <meta name="description" content="DevSnips is a clean and searchable library of HTML, CSS, and JavaScript snippets." />
   <link rel="stylesheet" href="assets/css/styles.css" />
   <link rel="icon" href="assets/images/favicon.ico" type="image/x-icon" />
 </head>
-<style>
-  body {
-  font-family: 'Segoe UI', sans-serif;
-  margin: 0;
-  padding: 0;
-  line-height: 1.6;
-  background: #f9f9f9;
-  color: #333;
-}
-
-.site-header {
-  background-color: #ffffff;
-  border-bottom: 1px solid #e0e0e0;
-  padding: 1rem 2rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.logo-container {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.site-nav ul {
-  display: flex;
-  list-style: none;
-  gap: 1.5rem;
-  padding: 0;
-  margin-top: 1rem;
-}
-
-.site-nav a {
-  text-decoration: none;
-  color: #007acc;
-}
-
-.snippets-section {
-  padding: 2rem;
-}
-
-.snippet-list {
-  list-style: none;
-  padding: 0;
-}
-
-.snippet-list li {
-  margin: 0.5rem 0;
-}
-
-.site-footer {
-  text-align: center;
-  padding: 1rem;
-  background: #f1f1f1;
-  font-size: 0.9rem;
-}
-</style>
 <body>
   <header class="site-header">
-    <div class="logo-container">
-      <img src="assets/images/devsnips-logo.svg" alt="DevSnips Logo" width="64" height="64" />
-      <div>
-        <h1>DevSnips</h1>
-        <p>Your personal HTML/CSS snippets library</p>
+    <div class="container header-inner">
+      <div class="brand">
+        <img src="assets/images/devsnips-logo.svg" alt="DevSnips Logo" width="56" height="56" />
+        <div>
+          <h1>DevSnips</h1>
+          <p>Practical snippets for faster front-end shipping</p>
+        </div>
       </div>
+      <nav aria-label="Primary">
+        <ul class="nav-list">
+          <li><a href="#snippets">Snippets</a></li>
+          <li><a href="snippets/html-snippets/">HTML</a></li>
+          <li><a href="snippets/css-snippets/">CSS</a></li>
+          <li><a href="snippets/js-snippets/">JavaScript</a></li>
+        </ul>
+      </nav>
     </div>
   </header>
+
+  <main class="container">
+    <section class="hero" aria-labelledby="hero-title">
+      <div class="hero-grid">
+        <article class="hero-card">
+          <h2 id="hero-title">A better snippets page: cleaner structure, better placement, improved UI.</h2>
+          <p>
+            Browse reusable snippets grouped by category so you can quickly find patterns for layout,
+            components, effects, accessibility, and interactions.
+          </p>
+          <div class="badges" aria-label="Library highlights">
+            <span>100+ snippets</span>
+            <span>Organized by topic</span>
+            <span>Ready to copy &amp; adapt</span>
+          </div>
+        </article>
+
+        <aside class="quick-links">
+          <h3>Quick Start</h3>
+          <ul>
+            <li><a href="snippets/css-snippets/">Explore CSS patterns</a></li>
+            <li><a href="snippets/html-snippets/">Browse semantic HTML</a></li>
+            <li><a href="snippets/js-snippets/">Check JavaScript helpers</a></li>
+          </ul>
+        </aside>
+      </div>
+    </section>
+
+    <section id="snippets" class="snippets-section" aria-labelledby="snippet-title">
+      <h3 id="snippet-title" class="section-title">Snippet Categories</h3>
+      <div class="snippet-grid">
+        <article class="category-card">
+          <h4>HTML Snippets</h4>
+          <p>Semantic page structures, forms, cards, modals, and reusable UI sections.</p>
+          <a href="snippets/html-snippets/">Open HTML snippets →</a>
+        </article>
+        <article class="category-card">
+          <h4>CSS Snippets</h4>
+          <p>Layouts, animations, effects, accessibility utilities, and modern CSS tricks.</p>
+          <a href="snippets/css-snippets/">Open CSS snippets →</a>
+        </article>
+        <article class="category-card">
+          <h4>JavaScript Snippets</h4>
+          <p>Interactive utilities and frontend behaviors to make your components feel alive.</p>
+          <a href="snippets/js-snippets/">Open JavaScript snippets →</a>
+        </article>
+      </div>
+    </section>
+  </main>
+
   <footer class="site-footer">
-    <p>&copy; 2025 <strong>DevSnips</strong> — Built with ❤️ by Sarthak</p>
+    <div class="container">
+      <p>&copy; 2026 <strong>DevSnips</strong> — Built with ❤️ by Sarthak</p>
+    </div>
   </footer>
 </body>
 </html>

--- a/devsnips/snippets/html-snippets/datalist-autocomplete.html
+++ b/devsnips/snippets/html-snippets/datalist-autocomplete.html
@@ -6,9 +6,9 @@
 <label for="browser">Choose your browser from the list:</label>
 <input list="browsers" name="browser" id="browser">
 <datalist id="browsers">
-  <option value="Edge">
-  <option value="Firefox">
-  <option value="Chrome">
-  <option value="Opera">
-  <option value="Safari">
+  <option value="Edge"></option>
+  <option value="Firefox"></option>
+  <option value="Chrome"></option>
+  <option value="Opera"></option>
+  <option value="Safari"></option>
 </datalist>


### PR DESCRIPTION
### Motivation
- Improve the snippets landing page structure, placement, and UI to make it easier to browse and find reusable patterns. 
- Replace brittle inline styles with a maintainable stylesheet and introduce a modern visual system for clearer hierarchy and spacing. 
- Ensure links and assets resolve correctly and the page is responsive and accessible.

### Description
- Rebuilt `devsnips/index.html` with a clearer semantic layout including a header/nav, hero area, quick-links aside, snippet category cards, and footer. 
- Removed inline page CSS and added a dedicated stylesheet at `devsnips/assets/css/styles.css` containing color tokens, card styles, responsive grid layout, sticky header, and mobile breakpoints. 
- Added meta description and small accessibility improvements such as `aria-labelledby` on key sections and clearer link targets for snippet categories. 
- Fixed the missing stylesheet path by creating `devsnips/assets/css/styles.css` and updated the page copy and year.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors. 
- Verified repository status with `git status --short` to confirm the intended files were staged. 
- Created a commit for the change which completed successfully (`git commit` reported the new file and modifications).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17004b3f14832990ff1ae23ad67b56)